### PR TITLE
Add rate limit handling to gql call

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ res = await store.execute_gql(
     query=QUERY,
     variables={'callbackUrl': 'https://my.app.com/webhooks'},
 )
-webhook_nodes = res['data']['webhookSubscription']['edges']
+webhook_nodes = res['webhookSubscription']['edges']
 ```
 
 ### Shopify OAuth

--- a/spylib/constants.py
+++ b/spylib/constants.py
@@ -2,3 +2,4 @@ API_VERSION: str = '2021-04'
 # Default assumes Shopify Plus rate
 RATE = 4
 MAX_TOKENS = 80
+THROTTLED_ERROR_MESSAGE = 'Throttled'

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -13,6 +13,12 @@ class ShopifyCallInvalidError(ShopifyError):
     pass
 
 
+class ShopifyThrottledError(ShopifyError):
+    """Exception to identify errors that are due to rate limit control"""
+
+    pass
+
+
 def not_our_fault(exception: Exception):
     """Simple function to identify invalid Shopify calls, i.e. our mistake.
 


### PR DESCRIPTION
- add throttled error handling and retry for`execute_gql`
- update the GraphQL API doc res, the gql call returns `jsondata['data']` not `jsondata` (this is different from the old spylib, I take it as an intentional change but the api doc has not reflected that, hence the fix in the doc here. )