### PR TITLE
Use callback_path variable in the redirect uri

### DIFF
--- a/spylib/oauth/redirects.py
+++ b/spylib/oauth/redirects.py
@@ -11,6 +11,7 @@ def oauth_init_url(
     domain: str,
     requested_scopes: List[str],
     callback_domain: str,
+    callback_path: str,
     is_login: bool,
     jwt_key: str,
 ) -> str:
@@ -31,7 +32,7 @@ def oauth_init_url(
     URL with all needed parameters to trigger the oauth process
     """
     scopes = ','.join(requested_scopes)
-    redirect_uri = f'https://{callback_domain}/callback'
+    redirect_uri = f'https://{callback_domain}{callback_path}'
     oauthjwt = OAuthJWT(
         is_login=is_login, storename=domain_to_storename(domain), nonce=get_unique_id()
     )

--- a/spylib/oauth/router.py
+++ b/spylib/oauth/router.py
@@ -48,6 +48,7 @@ def init_oauth_router(
                 is_login=False,
                 requested_scopes=app_scopes,
                 callback_domain=public_domain,
+                callback_path=callback_path,
                 jwt_key=private_key,
             )
         )
@@ -95,6 +96,7 @@ def init_oauth_router(
                     is_login=True,
                     requested_scopes=user_scopes,
                     callback_domain=public_domain,
+                    callback_path=callback_path,
                     jwt_key=private_key,
                 )
             )


### PR DESCRIPTION
Right now the oauth `redirect_uri` has the callback path hard coded. It doesn't work when the `callback_path` is set to something else. So here replace the hardcoded callback path with the `callback_path` variable 