### PR TITLE
Credit rate limit for GraphQL

### DIFF
--- a/spylib/constants.py
+++ b/spylib/constants.py
@@ -2,6 +2,25 @@ API_VERSION: str = '2021-04'
 # Default assumes Shopify Plus rate
 RATE = 4
 MAX_TOKENS = 80
-THROTTLED_ERROR_MESSAGE = 'Throttled'
 GRAPH_MAX = 1000  # Max rate for GraphQL
-GRAPH_LEAK = 50  # Leak rate per second for GraphQL
+
+"""
+These are the text error codes thrown by the GraphQL API. Although some errors
+throw a code e.g.
+
+    "errors": [
+        {
+            "message": "Throttled",
+            "extensions": {
+                "code": "THROTTLED"
+            }
+        }
+
+Not all provide the `code` parameter. Although you could just handle errors
+based on the message, this becomes very difficult as some of the messages
+are very long (see the max_cost_exceeded error output, which is ~350 characters)
+"""
+
+# Error Codes
+THROTTLED_ERROR_CODE = 'THROTTLED'
+MAX_COST_EXCEEDED_ERROR_CODE = 'MAX_COST_EXCEEDED'

--- a/spylib/constants.py
+++ b/spylib/constants.py
@@ -3,3 +3,5 @@ API_VERSION: str = '2021-04'
 RATE = 4
 MAX_TOKENS = 80
 THROTTLED_ERROR_MESSAGE = 'Throttled'
+GRAPH_MAX = 1000  # Max rate for GraphQL
+GRAPH_LEAK = 50  # Leak rate per second for GraphQL

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -19,6 +19,14 @@ class ShopifyThrottledError(ShopifyError):
     pass
 
 
+class ShopifyExceedingMaxCostError(ShopifyError):
+    """
+    Exception to identify errors that are due to queries exceeding the max query size
+    """
+
+    pass
+
+
 def not_our_fault(exception: Exception):
     """Simple function to identify invalid Shopify calls, i.e. our mistake.
 

--- a/spylib/store.py
+++ b/spylib/store.py
@@ -179,8 +179,10 @@ class Store:
             )
             if MAX_COST_EXCEEDED_ERROR_CODE in error_code_list:
                 raise ShopifyExceedingMaxCostError(
-                    f'Store {self.name}: The Shopify API token is throttling.'
-                    f' Query cost is too large (>{GRAPH_MAX}) and will never run'
+                    f'Store {self.name}: This query was rejected by the Shopify'
+                    f' API, and will never run as written, as the query cost'
+                    f' is larger than the max possible query size (>{GRAPH_MAX})'
+                    ' for Shopify.'
                 )
             elif THROTTLED_ERROR_CODE in error_code_list:  # This should be the last condition
                 query_cost = jsondata['extensions']['cost']['requestedQueryCost']

--- a/spylib/store.py
+++ b/spylib/store.py
@@ -171,16 +171,6 @@ class Store:
                 [err['message'] for err in jsondata['errors'] if 'message' in err]
             )
             if THROTTLED_ERROR_MESSAGE in errorlist:
-                """
-                Note for self, remove;
-
-                This will throw when the requestedQueryCost is more than the GRAPH_MAX.
-                This means we need to check if the query cost is > 1000, which means
-                that the query will never be run, else we need to wait until the pool
-                refils sufficiently to execute the query.
-                """
-                with open("foo.txt", "w") as f:
-                    f.write(jsondata)
                 if jsondata['cost']['requestedQueryCost'] > GRAPH_MAX:
                     raise ShopifyThrottledError(
                         f'Store {self.name}: The Shopify API token is throttling. \

--- a/spylib/store.py
+++ b/spylib/store.py
@@ -142,7 +142,6 @@ class Store:
 
     @retry(
         reraise=True,
-        wait=wait_random(min=1, max=2),
         stop=stop_after_attempt(5),
         retry=retry_if_exception_type(ShopifyThrottledError),
     )

--- a/spylib/store.py
+++ b/spylib/store.py
@@ -1,5 +1,5 @@
 from asyncio import sleep
-from math import floor
+from math import floor, ceil
 from time import monotonic
 from typing import Any, Dict, Optional
 
@@ -186,7 +186,7 @@ class Store:
                 query_cost = jsondata['extensions']['cost']['requestedQueryCost']
                 available = jsondata['extensions']['cost']['throttleStatus']['currentlyAvailable']
                 rate = jsondata['extensions']['cost']['throttleStatus']["restoreRate"]
-                sleep_time = round((query_cost - available) / rate, 0)
+                sleep_time = ceil((query_cost - available) / rate)
                 await sleep(sleep_time)
                 raise ShopifyThrottledError
             else:

--- a/spylib/store.py
+++ b/spylib/store.py
@@ -1,5 +1,5 @@
 from asyncio import sleep
-from math import floor, ceil
+from math import ceil, floor
 from time import monotonic
 from typing import Any, Dict, Optional
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -208,6 +208,9 @@ async def test_store_graphql_tokeninvalid(mocker):
 
 @pytest.mark.asyncio
 async def test_store_graphql_throttling(mocker):
+    """
+    Tests the throttling of the graphQL requests.
+    """
     store = Store(store_id='TEST', name='test-store', access_token='Te5tM3')
 
     query = '''


### PR DESCRIPTION
Added in the logic for handling GraphQL rate limiting. It currently calculates the minimum amount of time required to be able to re-fill the bucket before attempting to re-submit the query. It completely kills the request if it will never run (> 1000).