### PR TITLE
Fix session token format

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ functionality can be used to verify the session for the user. The suggested synt
 ```python
 from spylib.utils import SessionToken
 
-decode_session_token = partial(SessionToken.decode_token_from_header, api_key=api_key, secret=secret)
+decode_session_token = partial(SessionToken.parse, api_key=api_key, secret=secret)
 ```
 
 Then this can be used as a dependency in FastAPI by doing the following:

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ as arguments.
 ### Session Tokens
 
 The [session token](https://shopify.dev/apps/auth/session-tokens/authenticate-an-embedded-app-using-session-tokens)
-functionality can be used to verify the session for the user. The suggested syntax is to define a partial function:
+functionality can be used to verify the session for the user. The suggested syntax is to define a dependency:
 
 ```python
 from spylib.utils import SessionToken
@@ -284,7 +284,7 @@ def parse_session_token(request: Request):
     SessionToken.from_header(request.headers.get('Authorization'), api_key, secret)
 ```
 
-Then this can be used as a dependency in FastAPI by doing the following:
+This can be used in FastAPI in the following way:
 
 ```python
 @app.get("/items/")

--- a/README.md
+++ b/README.md
@@ -280,14 +280,15 @@ functionality can be used to verify the session for the user. The suggested synt
 ```python
 from spylib.utils import SessionToken
 
-decode_session_token = partial(SessionToken.parse, api_key=api_key, secret=secret)
+def parse_session_token(request: Request):
+    SessionToken.from_header(request.headers.get('Authorization'), api_key, secret)
 ```
 
 Then this can be used as a dependency in FastAPI by doing the following:
 
 ```python
 @app.get("/items/")
-async def read_items(session: SessionToken = Depends(decode_session_token)):
+async def read_items(session: SessionToken = Depends(parse_session_token)):
   # Some api code
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -275,19 +275,20 @@ as arguments.
 ### Session Tokens
 
 The [session token](https://shopify.dev/apps/auth/session-tokens/authenticate-an-embedded-app-using-session-tokens)
-functionality can be used to verify the session for the user. The suggested syntax is to define a partial function:
+functionality can be used to verify the session for the user. The suggested syntax is to define a dependency:
 
 ```python
 from spylib.utils import SessionToken
 
-decode_session_token = partial(SessionToken.decode_token_from_header, api_key=api_key, secret=secret)
+def parse_session_token(request: Request):
+    SessionToken.from_header(request.headers.get('Authorization'), api_key, secret)
 ```
 
-Then this can be used as a dependency in FastAPI by doing the following:
+This can be used in FastAPI in the following way:
 
 ```python
 @app.get("/items/")
-async def read_items(session: SessionToken = Depends(decode_session_token)):
+async def read_items(session: SessionToken = Depends(parse_session_token)):
   # Some api code
 ```
 

--- a/spylib/utils/session_token.py
+++ b/spylib/utils/session_token.py
@@ -45,7 +45,7 @@ class SessionToken(BaseModel):
     exp: Optional[float]
     nbf: Optional[float]
     iat: Optional[float]
-    jti: int
+    jti: str
     sid: str
 
     @root_validator()

--- a/spylib/utils/session_token.py
+++ b/spylib/utils/session_token.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
-from fastapi import Request
 from jwt import decode
 from pydantic import root_validator
 from pydantic.main import BaseModel
@@ -63,10 +62,6 @@ class SessionToken(BaseModel):
             raise MismatchedHostError(f'The issuer {iss} does not match the destination {dest}')
 
         return values
-
-    @classmethod
-    def parse(cls, request: Request, api_key: str, secret: str):
-        cls.from_header(request.headers.get("authorization"), api_key, secret)
 
     @classmethod
     def from_header(

--- a/spylib/utils/session_token.py
+++ b/spylib/utils/session_token.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
+from fastapi import Request
 from jwt import decode
 from pydantic import root_validator
 from pydantic.main import BaseModel
@@ -64,13 +65,16 @@ class SessionToken(BaseModel):
         return values
 
     @classmethod
+    def parse(cls, request: Request, api_key: str, secret: str):
+        cls.from_header(request.headers.get("authorization"), api_key, secret)
+
+    @classmethod
     def from_header(
         cls,
         authorization_header: str,
         api_key: str,
         secret: str,
     ) -> SessionToken:
-
         # Take the authorization headers and unload them
         if not authorization_header.startswith(PREFIX):
             raise TokenAuthenticationError(

--- a/tests/utils/test_session_token.py
+++ b/tests/utils/test_session_token.py
@@ -1,7 +1,11 @@
 from datetime import datetime, timedelta
+from functools import partial
 
 import jwt
 import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
 
 from spylib.utils.session_token import (
     InvalidIssuerError,
@@ -28,7 +32,7 @@ def get_token():
         'exp': (now + timedelta(0, 60)).timestamp(),
         'nbf': (now - timedelta(0, 60)).timestamp(),
         'iat': now.timestamp(),
-        'jti': 123,
+        'jti': '3512a085-ee9a-4914-b252-3aabcd1ada14',
         'sid': 'abc123',
     }
 
@@ -80,3 +84,22 @@ async def test_invalid_token_parameters(token, parameter, value, error):
     header = generate_auth_header(token)
     with pytest.raises(error):
         SessionToken.from_header(header, API_KEY, API_SECRET)
+
+
+def parse_session_token(request: Request):
+    SessionToken.from_header(request.headers.get('Authorization'), API_KEY, API_SECRET)
+
+
+@pytest.mark.asyncio
+async def test_depends(token):
+    app = FastAPI()
+
+    @app.get("/token")
+    async def token_endpoint(token: SessionToken = Depends(parse_session_token)):
+        return token
+
+    client = TestClient(app=app)
+
+    header = generate_auth_header(token)
+
+    client.get("/token", headers={'Authorization': header})

--- a/tests/utils/test_session_token.py
+++ b/tests/utils/test_session_token.py
@@ -93,7 +93,7 @@ def parse_session_token(request: Request):
 async def test_depends(token):
     app = FastAPI()
 
-    @app.get("/token")
+    @app.get('/token')
     async def token_endpoint(token: SessionToken = Depends(parse_session_token)):
         return token
 
@@ -101,4 +101,4 @@ async def test_depends(token):
 
     header = generate_auth_header(token)
 
-    client.get("/token", headers={'Authorization': header})
+    client.get('/token', headers={'Authorization': header})

--- a/tests/utils/test_session_token.py
+++ b/tests/utils/test_session_token.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from functools import partial
 
 import jwt
 import pytest


### PR DESCRIPTION
The session token format was not described properly in the README. This has been updated to illustrate the whole process, including a new test which should match the process of pulling the token from the header.