### PR TITLE
✨ Feature/webhook create

### DIFF
--- a/scripts/test_suite.sh
+++ b/scripts/test_suite.sh
@@ -23,7 +23,7 @@ FLAKE8OUT=`flake8`
 reportvalidation "$FLAKE8OUT"
 
 echo -ne "\n######### CHECK FORMATTING: "
-BLACKOUT=`black spylib tests --check 2>&1`
+BLACKOUT=`brunette spylib tests --check 2>&1 --skip-string-normalization`
 if [[ $BLACKOUT == "All done!"* ]]
 then
   echo "OK"

--- a/spylib/__init__.py
+++ b/spylib/__init__.py
@@ -3,6 +3,20 @@
 __version__ = '0.5.0'
 
 
-from .token import OfflineTokenABC, OnlineTokenABC, PrivateTokenABC, Token
+from .token import (
+    OfflineTokenABC,
+    OnlineTokenABC,
+    PrivateTokenABC,
+    Token,
+    WebhookResponse,
+    WebhookTopic,
+)
 
-__all__ = ['OfflineTokenABC', 'OnlineTokenABC', 'PrivateTokenABC', 'Token']
+__all__ = [
+    'OfflineTokenABC',
+    'OnlineTokenABC',
+    'PrivateTokenABC',
+    'Token',
+    'WebhookResponse',
+    'WebhookTopic',
+]

--- a/spylib/constants.py
+++ b/spylib/constants.py
@@ -23,4 +23,3 @@ OPERATION_NAME_REQUIRED_ERROR_MESSAGE = 'An operation name is required'
 WRONG_OPERATION_NAME_ERROR_MESSAGE = (
     'No operation named "{}"'  # Required as they don't stay consistant
 )
-WEBHOOK_JSON_FORMAT = 'JSON'

--- a/spylib/constants.py
+++ b/spylib/constants.py
@@ -23,3 +23,4 @@ OPERATION_NAME_REQUIRED_ERROR_MESSAGE = 'An operation name is required'
 WRONG_OPERATION_NAME_ERROR_MESSAGE = (
     'No operation named "{}"'  # Required as they don't stay consistant
 )
+WEBHOOK_JSON_FORMAT = 'JSON'

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -10,6 +10,12 @@ class ShopifyGQLError(Exception):
     pass
 
 
+class ShopifyGQLUserError(Exception):
+    """Exception to identify any Shopify admin graphql error caused by the user mistake"""
+
+    pass
+
+
 class ShopifyCallInvalidError(ShopifyError):
     """Exception to identify errors that our due to bad data sent by us
 

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from math import ceil, floor
 from time import monotonic
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, Union
 
 from httpx import AsyncClient, Response
 from pydantic import BaseModel, validator
@@ -278,7 +278,7 @@ class Token(ABC, BaseModel):
 
     async def create_http_webhook(
         self,
-        topic: WebhookTopic,
+        topic: Union[WebhookTopic, str],
         callback_url: str,
         include_fields=None,
         metafield_namespaces=None,
@@ -308,7 +308,7 @@ class Token(ABC, BaseModel):
             }
         '''
         variables = {
-            'topic': topic.value,
+            'topic': topic.value if isinstance(topic, WebhookTopic) else topic,
             'webhookSubscription': {
                 'callbackUrl': callback_url,
                 'format': WEBHOOK_JSON_FORMAT,

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -279,9 +279,9 @@ class Token(ABC, BaseModel):
         self,
         topic: Union[WebhookTopic, str],
         callback_url: str,
-        include_fields=None,
-        metafield_namespaces=None,
-        private_metafield_namespaces=None,
+        include_fields: Optional[List[str]] = None,
+        metafield_namespaces: Optional[List[str]] = None,
+        private_metafield_namespaces: Optional[List[str]] = None,
     ) -> WebhookResponse:
         """Uses graphql to create a webhook"""
         query = '''
@@ -326,9 +326,9 @@ class Token(ABC, BaseModel):
         self,
         topic: Union[WebhookTopic, str],
         arn: str,
-        include_fields=None,
-        metafield_namespaces=None,
-        private_metafield_namespaces=None,
+        include_fields: Optional[List[str]] = None,
+        metafield_namespaces: Optional[List[str]] = None,
+        private_metafield_namespaces: Optional[List[str]] = None,
     ) -> WebhookResponse:
         # TODO
         raise NotImplementedError
@@ -338,9 +338,9 @@ class Token(ABC, BaseModel):
         topic: Union[WebhookTopic, str],
         pubsub_project: str,
         pubsub_topic: str,
-        include_fields=None,
-        metafield_namespaces=None,
-        private_metafield_namespaces=None,
+        include_fields: Optional[List[str]] = None,
+        metafield_namespaces: Optional[List[str]] = None,
+        private_metafield_namespaces: Optional[List[str]] = None,
     ) -> WebhookResponse:
         # TODO
         raise NotImplementedError

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -323,6 +323,29 @@ class Token(ABC, BaseModel):
             raise ShopifyGQLUserError(res)
         return WebhookResponse(id=webhook_create['webhookSubscription']['id'])
 
+    async def create_event_bridge_webhook(
+        self,
+        topic: Union[WebhookTopic, str],
+        arn: str,
+        include_fields=None,
+        metafield_namespaces=None,
+        private_metafield_namespaces=None,
+    ) -> WebhookResponse:
+        # TODO
+        pass
+
+    async def create_pubsub_webhook(
+        self,
+        topic: Union[WebhookTopic, str],
+        pubsub_project: str,
+        pubsub_topic: str,
+        include_fields=None,
+        metafield_namespaces=None,
+        private_metafield_namespaces=None,
+    ) -> WebhookResponse:
+        # TODO
+        pass
+
 
 class OfflineTokenABC(Token, ABC):
     """

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -19,7 +19,6 @@ from spylib.constants import (
     MAX_COST_EXCEEDED_ERROR_CODE,
     OPERATION_NAME_REQUIRED_ERROR_MESSAGE,
     THROTTLED_ERROR_CODE,
-    WEBHOOK_JSON_FORMAT,
     WRONG_OPERATION_NAME_ERROR_MESSAGE,
 )
 from spylib.exceptions import (
@@ -311,7 +310,7 @@ class Token(ABC, BaseModel):
             'topic': topic.value if isinstance(topic, WebhookTopic) else topic,
             'webhookSubscription': {
                 'callbackUrl': callback_url,
-                'format': WEBHOOK_JSON_FORMAT,
+                'format': 'JSON',
                 'includeFields': include_fields,
                 'metafieldNamespaces': metafield_namespaces,
                 'privateMetafieldNamespaces': private_metafield_namespaces,

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -332,7 +332,7 @@ class Token(ABC, BaseModel):
         private_metafield_namespaces=None,
     ) -> WebhookResponse:
         # TODO
-        pass
+        raise NotImplementedError
 
     async def create_pubsub_webhook(
         self,
@@ -344,7 +344,7 @@ class Token(ABC, BaseModel):
         private_metafield_namespaces=None,
     ) -> WebhookResponse:
         # TODO
-        pass
+        raise NotImplementedError
 
 
 class OfflineTokenABC(Token, ABC):

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -19,6 +19,7 @@ from spylib.constants import (
     MAX_COST_EXCEEDED_ERROR_CODE,
     OPERATION_NAME_REQUIRED_ERROR_MESSAGE,
     THROTTLED_ERROR_CODE,
+    WEBHOOK_JSON_FORMAT,
     WRONG_OPERATION_NAME_ERROR_MESSAGE,
 )
 from spylib.exceptions import (
@@ -310,7 +311,7 @@ class Token(ABC, BaseModel):
             'topic': topic.value,
             'webhookSubscription': {
                 'callbackUrl': callback_url,
-                'format': 'JSON',
+                'format': WEBHOOK_JSON_FORMAT,
                 'includeFields': include_fields,
                 'metafieldNamespaces': metafield_namespaces,
                 'privateMetafieldNamespaces': private_metafield_namespaces,

--- a/tests/token/test_webhook_create.py
+++ b/tests/token/test_webhook_create.py
@@ -75,7 +75,7 @@ async def test_store_http_webhook_create_usererrors(mocker):
         await token.create_http_webhook(
             topic=WebhookTopic.ORDERS_CREATE,
             callback_url='https://example.org/endpoint',
-            include_fields=["id", "note"],
+            include_fields=['id', 'note'],
         )
 
     assert shopify_request_mock.call_count == 1
@@ -104,7 +104,7 @@ async def test_store_http_webhook_create_invalidtopic(mocker):
         await token.create_http_webhook(
             topic='invalid topic',
             callback_url='https://example.org/endpoint',
-            include_fields=["id", "note"],
+            include_fields=['id', 'note'],
         )
 
     assert shopify_request_mock.call_count == 1

--- a/tests/token/test_webhook_create.py
+++ b/tests/token/test_webhook_create.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from spylib import WebhookResponse, WebhookTopic
+
+from ..token_classes import MockHTTPResponse, OfflineToken, test_information
+
+
+@pytest.mark.asyncio
+async def test_store_http_webhook_create_happypath(mocker):
+    token = await OfflineToken.load(store_name=test_information.store_name)
+
+    webhook_id = 'gid://shopify/WebhookSubscription/7191874123'
+    gql_response = {
+        'data': {
+            'webhookSubscriptionCreate': {
+                'webhookSubscription': {
+                    'id': webhook_id,
+                    'topic': 'ORDERS_CREATE',
+                    'format': 'JSON',
+                    'includeFields': ['id', 'note'],
+                    'endpoint': {
+                        '__typename': 'WebhookHttpEndpoint',
+                        'callbackUrl': 'https://example.org/endpoint',
+                    },
+                }
+            }
+        }
+    }
+
+    shopify_request_mock = mocker.patch(
+        'httpx.AsyncClient.request',
+        new_callable=AsyncMock,
+        return_value=MockHTTPResponse(status_code=200, jsondata=gql_response),
+    )
+
+    res = await token.create_http_webhook(
+        topic=WebhookTopic.ORDERS_CREATE,
+        callback_url='https://example.org/endpoint',
+        include_fields=["id", "note"],
+    )
+
+    shopify_request_mock.assert_called_once()
+
+    assert res == WebhookResponse(id=webhook_id)

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -30,7 +30,7 @@ online_token_data = OnlineTokenResponse(
 
 offline_token_data = OfflineTokenResponse(
     access_token='OFFLINETOKEN',
-    scope=','.join(['write_products', 'read_customers']),
+    scope=','.join(['write_products', 'read_customers', 'write_orders']),
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ commands =
 whitelist_externals = poetry
 commands =
     poetry install -v
-    brunette spylib tests --check
+    brunette spylib tests --check --skip-string-normalization


### PR DESCRIPTION
fix #109 

- add `webhook_http_create` for creating webhooks using [`webhookSubscriptionCreate`](https://shopify.dev/api/admin-graphql/2022-01/mutations/webhookSubscriptionCreate) with `callback_url`
- add happy path and user error tests 

**Questions:**
just checking before I proceed
- I just put the payload in the method right now. Do you have a better way to put it, e.g. in a file like we do in other repos? 
- I added the placeholders for the webhook create methods for the aws event bridge and the google cloud pubsub ones. I plan to implement them like `webhook_http_create` using [eventBridgeWebhookSubscriptionCreate](https://shopify.dev/api/admin-graphql/2022-01/mutations/eventBridgeWebhookSubscriptionCreate), [pubSubWebhookSubscriptionCreate](https://shopify.dev/api/admin-graphql/2022-01/mutations/pubSubWebhookSubscriptionCreate) and . Do you have on mind any other plan for their implementation? 
- I am thinking to copy our most used webhook topics into the enum from the Shopify list [here](https://shopify.dev/api/admin-graphql/2022-01/enums/WebhookSubscriptionTopic). OR do you suggest to just copy all?
