### PR TITLE
✨ 💥 Feature/webhook verification

### DIFF
--- a/spylib/__init__.py
+++ b/spylib/__init__.py
@@ -10,6 +10,7 @@ from .token import (
     Token,
     WebhookResponse,
     WebhookTopic,
+    verify_webhook,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     'Token',
     'WebhookResponse',
     'WebhookTopic',
+    'verify_webhook',
 ]

--- a/spylib/__init__.py
+++ b/spylib/__init__.py
@@ -10,7 +10,7 @@ from .token import (
     Token,
     WebhookResponse,
     WebhookTopic,
-    verify_webhook,
+    is_webhook_valid,
 )
 
 __all__ = [
@@ -20,5 +20,5 @@ __all__ = [
     'Token',
     'WebhookResponse',
     'WebhookTopic',
-    'verify_webhook',
+    'is_webhook_valid',
 ]

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -30,6 +30,7 @@ from spylib.exceptions import (
     ShopifyThrottledError,
     not_our_fault,
 )
+from spylib.utils.hmac import validate
 from spylib.utils.rest import Request
 
 
@@ -400,3 +401,11 @@ class PrivateTokenABC(Token, ABC):
         therefore the developer should override this.
         """
         pass
+
+
+def verify_webhook(data: str, hmac_header: str, api_secret_key: str) -> bool:
+    try:
+        validate(secret=api_secret_key, sent_hmac=hmac_header, message=data, use_base64=True)
+    except ValueError:
+        return False
+    return True

--- a/spylib/token.py
+++ b/spylib/token.py
@@ -403,7 +403,7 @@ class PrivateTokenABC(Token, ABC):
         pass
 
 
-def verify_webhook(data: str, hmac_header: str, api_secret_key: str) -> bool:
+def is_webhook_valid(data: str, hmac_header: str, api_secret_key: str) -> bool:
     try:
         validate(secret=api_secret_key, sent_hmac=hmac_header, message=data, use_base64=True)
     except ValueError:

--- a/spylib/utils/hmac.py
+++ b/spylib/utils/hmac.py
@@ -12,7 +12,9 @@ def calculate_from_message(secret: str, message: str, use_base64: bool = False) 
     return hmac_hash.hexdigest()
 
 
-def calculate_from_components(datetime, path, query_string, body, secret, use_base64: bool = False):
+def calculate_from_components(
+    datetime, path, query_string, body, secret, use_base64: bool = False
+):
     if query_string != '':
         path = path + '?' + query_string
     message = path + datetime + body

--- a/spylib/utils/hmac.py
+++ b/spylib/utils/hmac.py
@@ -3,25 +3,25 @@ from hashlib import sha256
 from hmac import compare_digest, new
 
 
-def calculate_from_message(secret: str, message: str, is_base64: bool = False) -> str:
+def calculate_from_message(secret: str, message: str, use_base64: bool = False) -> str:
     hmac_hash = new(secret.encode('utf-8'), message.encode('utf-8'), sha256)
-    if is_base64:
+    if use_base64:
         # TODO fix bytes / str union issue
         return b64encode(hmac_hash.digest()).decode('utf-8')
 
     return hmac_hash.hexdigest()
 
 
-def calculate_from_components(datetime, path, query_string, body, secret, is_base64: bool = False):
+def calculate_from_components(datetime, path, query_string, body, secret, use_base64: bool = False):
     if query_string != '':
         path = path + '?' + query_string
     message = path + datetime + body
-    return calculate_from_message(secret=secret, message=message, is_base64=is_base64)
+    return calculate_from_message(secret=secret, message=message, use_base64=use_base64)
 
 
-def validate(secret: str, sent_hmac: str, message: str, is_base64: bool = False):
+def validate(secret: str, sent_hmac: str, message: str, use_base64: bool = False):
 
-    hmac_calculated = calculate_from_message(secret=secret, message=message, is_base64=is_base64)
+    hmac_calculated = calculate_from_message(secret=secret, message=message, use_base64=use_base64)
 
     if not compare_digest(sent_hmac, hmac_calculated):
         raise ValueError('HMAC verification failed')

--- a/tests/token/test_webhook_verification.py
+++ b/tests/token/test_webhook_verification.py
@@ -1,16 +1,20 @@
-from spylib.token import verify_webhook
+import pytest
+from pytest import param
+
+from spylib.token import is_webhook_valid
 
 API_SECRET = 'secret'
 MESSAGE = 'message'
 VALID_HMAC = 'i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs='
 INVALID_HMAC = 'hmac'
 
+params = [
+    param(API_SECRET, MESSAGE, VALID_HMAC, True, id='hmac is valid'),
+    param(API_SECRET, MESSAGE, INVALID_HMAC, False, id='hmac is invalid'),
+]
 
-def test_verify_webhook_valid():
-    is_valid = verify_webhook(data=MESSAGE, hmac_header=VALID_HMAC, api_secret_key=API_SECRET)
-    assert is_valid is True
 
-
-def test_verify_webhook_invalid():
-    is_valid = verify_webhook(data=MESSAGE, hmac_header=INVALID_HMAC, api_secret_key=API_SECRET)
-    assert is_valid is False
+@pytest.mark.parametrize('api_secret,data, hmac_header, expected_is_valid', params)
+def test_is_webhook_valid(api_secret, data, hmac_header, expected_is_valid):
+    is_valid = is_webhook_valid(data=data, hmac_header=hmac_header, api_secret_key=api_secret)
+    assert is_valid is expected_is_valid

--- a/tests/token/test_webhook_verification.py
+++ b/tests/token/test_webhook_verification.py
@@ -1,0 +1,16 @@
+from spylib.token import verify_webhook
+
+API_SECRET = 'secret'
+MESSAGE = 'message'
+VALID_HMAC = 'i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs='
+INVALID_HMAC = 'hmac'
+
+
+def test_verify_webhook_valid():
+    is_valid = verify_webhook(data=MESSAGE, hmac_header=VALID_HMAC, api_secret_key=API_SECRET)
+    assert is_valid is True
+
+
+def test_verify_webhook_invalid():
+    is_valid = verify_webhook(data=MESSAGE, hmac_header=INVALID_HMAC, api_secret_key=API_SECRET)
+    assert is_valid is False


### PR DESCRIPTION
fix #110 

- rename hmac functions param `is_base64` to `use_base64`
- add ~~`verify_webhook`~~ `is_webhook_valid` function
- add tests
