### PR TITLE
👷 fix dependencies reinstallation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ python =
 [testenv]
 whitelist_externals = poetry
 commands =
+    poetry install -v
     poetry run pytest --cov=spylib --cov-report term-missing tests/
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -13,29 +13,13 @@ whitelist_externals = poetry
 commands =
     poetry install -v
     poetry run pytest --cov=spylib --cov-report term-missing tests/
-
-[testenv:mypy]
-whitelist_externals = poetry
-commands =
     mypy spylib
+    flake8 spylib tests
+    brunette spylib tests --check --skip-string-normalization
+    linkcheckMarkdown docs
 
 [testenv:with_fastapi]
 whitelist_externals = poetry
 commands =
     poetry install -E fastapi
     poetry run pytest --cov=spylib --cov-report term-missing tests/
-
-[testenv:flake8]
-whitelist_externals = poetry
-commands =
-    flake8 spylib tests
-
-[testenv:brunette]
-whitelist_externals = poetry
-commands =
-    brunette spylib tests --check --skip-string-normalization
-
-[testenv:linkcheckmd]
-whitelist_externals = poetry
-commands =
-    linkcheckMarkdown docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 isolated_build = true
-envlist = py{38,39,310}, with_fastapi, flake8, mypy, brunette, linkcheckmd
+envlist = py{38,39,310}, with_fastapi
 
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
-    3.10: py310, with_fastapi, flake8, mypy, brunette, linkcheckmd
+    3.10: py310, with_fastapi
 
 [testenv]
 whitelist_externals = poetry

--- a/tox.ini
+++ b/tox.ini
@@ -11,36 +11,30 @@ python =
 [testenv]
 whitelist_externals = poetry
 commands =
-    poetry install -v
     poetry run pytest --cov=spylib --cov-report term-missing tests/
 
 [testenv:mypy]
 whitelist_externals = poetry
 commands =
-    poetry install -v
     mypy spylib
 
 [testenv:with_fastapi]
 whitelist_externals = poetry
 commands =
-    poetry install -v
     poetry install -E fastapi
     poetry run pytest --cov=spylib --cov-report term-missing tests/
 
 [testenv:flake8]
 whitelist_externals = poetry
 commands =
-    poetry install -v
     flake8 spylib tests
 
 [testenv:brunette]
 whitelist_externals = poetry
 commands =
-    poetry install -v
     brunette spylib tests --check --skip-string-normalization
 
 [testenv:linkcheckmd]
 whitelist_externals = poetry
 commands =
-    poetry install -v
     linkcheckMarkdown docs


### PR DESCRIPTION
Quinn pointed out that the dependencies have been reinstalled many times in the python 310 test environment and the overall CI takes a long time to run
![tests](https://user-images.githubusercontent.com/26753845/168172468-57cf7265-e56a-4c3f-9e39-e1bc84e8a4b5.JPG)

