### PR TITLE
:sparkles: auth utility functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pydocstyle = "6.1.1"
 linkcheckmd= "1.4.0"
 
 fastapi = { version = ">= 0.69.0", optional = true }
+pytest-httpx = "^0.21.0"
 
 [tool.poetry.extras]
 fastapi = ["fastapi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ mkdocs-material = "7.3.6"
 lazydocs = "0.4.8"
 pydocstyle = "6.1.1"
 linkcheckmd= "1.4.0"
+respx = "0.19.2"
 
 fastapi = { version = ">= 0.69.0", optional = true }
-pytest-httpx = "^0.21.0"
 
 [tool.poetry.extras]
 fastapi = ["fastapi"]

--- a/spylib/oauth/__init__.py
+++ b/spylib/oauth/__init__.py
@@ -1,2 +1,8 @@
-from .fastapi import init_oauth_router  # noqa: F401
+from .perform_token_exchange import (
+    OfflineTokenResponse,
+    OnlineTokenResponse,
+    perform_token_exchange,
+)
 from .tokens import OfflineToken, OnlineToken  # noqa: F401
+
+__all__ = ['perform_token_exchange']

--- a/spylib/oauth/perform_token_exchange.py
+++ b/spylib/oauth/perform_token_exchange.py
@@ -1,0 +1,116 @@
+from typing import List, Union
+
+from httpx import AsyncClient, codes
+from pydantic import BaseModel, validator
+
+
+def parse_scope(scope: str) -> List[str]:
+    return scope.split(',')
+
+
+# Docstrings would be fully completed
+# Types would potentially be moved to .types
+
+
+class OfflineTokenResponse(BaseModel):   # I don't love this naming
+    """
+    [Read more about Offline access](https://shopify.dev/apps/auth/oauth/access-modes#offline-access)
+    """
+
+    access_token: str
+    """
+    An API access token that can be used to access the shop’s data as long as your app is installed. Your app should store the token somewhere to make authenticated requests for a shop’s data.
+    """
+    scope: List[str]
+    """
+    The list of access scopes that were granted to your app and are associated with the access token.
+    """
+
+    _normalize_scope = validator('scope', allow_reuse=True, pre=True)(parse_scope)
+
+
+class AssociatedUser(BaseModel):
+    id: int
+    first_name: str
+    last_name: str
+    email: str
+    email_verified: bool
+    account_owner: bool
+    locale: str
+    collaborator: bool
+
+
+class OnlineTokenResponse(BaseModel):
+    """
+    [Read more about Online access](https://shopify.dev/apps/auth/oauth/access-modes#online-access)
+    """
+
+    access_token: str
+    """
+    
+    """
+    scope: List[str]
+    """
+    The list of access scopes that were requested to be associated with the access token.
+    """
+
+    _normalize_scope = validator('scope', allow_reuse=True, pre=True)(parse_scope)
+
+    expires_in: int
+    associated_user_scope: List[str]
+
+    _normalize_associated_user_scope = validator(
+        'associated_user_scope', allow_reuse=True, pre=True
+    )(parse_scope)
+
+    """
+    The list of access scopes that were granted to associated with the access token.
+    """
+    associated_user: AssociatedUser
+
+
+async def perform_token_exchange(
+    *,
+    code: str,
+    shop: str,
+    api_key: str,
+    api_secret_key: str,
+) -> Union[OnlineTokenResponse, OfflineTokenResponse]:
+    """_summary_
+
+    Args:
+        code (str): _description_
+        shop (str): _description_
+        api_key (str): _description_
+        api_secret_key (str): _description_
+
+    Raises:
+        Exception: _description_
+
+    Returns:
+        Union[OnlineTokenResponse, OfflineTokenResponse]: _description_
+    """
+
+    async with AsyncClient(base_url=f'https://{shop}') as client:
+        response = await client.post(
+            url='/admin/oauth/access_token',
+            json={
+                'code': code,
+                'client_id': api_key,
+                'client_secret': api_secret_key,
+            },
+        )
+
+    if response.status_code != codes.OK:
+        message = (
+            f'Shopify rejected token exchange. Shop: "{shop}". Status "{response.status_code}"'
+        )
+        raise Exception(message)   # Not sure what the convention is here
+
+    raw_response_body = response.json()
+    is_online_token = hasattr(raw_response_body, 'associated_user')
+
+    if is_online_token:
+        return OnlineTokenResponse.parse_obj(raw_response_body)
+
+    return OfflineTokenResponse.parse_obj(raw_response_body)

--- a/spylib/oauth/perform_token_exchange.py
+++ b/spylib/oauth/perform_token_exchange.py
@@ -108,7 +108,7 @@ async def perform_token_exchange(
         raise Exception(message)   # Not sure what the convention is here
 
     raw_response_body = response.json()
-    is_online_token = hasattr(raw_response_body, 'associated_user')
+    is_online_token = 'associated_user' in raw_response_body
 
     if is_online_token:
         return OnlineTokenResponse.parse_obj(raw_response_body)

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -64,7 +64,7 @@ class MockHTTPResponse:
 @pytest.mark.asyncio
 async def test_oauth_without_fastapi():
     with pytest.raises(FastAPIImportError):
-        import spylib.oauth  # noqa: F401
+        import spylib.oauth.fastapi  # noqa: F401
 
 
 @pytest.mark.asyncio

--- a/tests/oauth/test_perform_token_exchange.py
+++ b/tests/oauth/test_perform_token_exchange.py
@@ -1,0 +1,54 @@
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+shop = 'example.myshopify.com'
+online_token_response = dict(
+    access_token='online-token',
+    scope='write_products',
+    expires_in=86399,
+    associated_user_scope='read_products',
+    associated_user=dict(
+        id=902541635,
+        first_name='John',
+        last_name='Smith',
+        email='john@example.com',
+        email_verified=True,
+        account_owner=True,
+        locale='en',
+        collaborator=False,
+    ),
+)
+
+# Would be parametrized
+@pytest.mark.asyncio
+async def test_perform_token_exchange(httpx_mock: HTTPXMock):
+    # Would move this functionality into a fixture
+    # I'd love a nicer way to do this in fact, features needed:
+    # throw if not called, assert on body, mock response
+    httpx_mock.add_response(
+        url=f'https://{shop}/admin/oauth/access_token',
+        method='POST',
+        json=online_token_response,
+        # This is not great - key order matters since we are comparing a byte stream
+        match_content=bytes(
+            json.dumps(
+                {
+                    'code': 'code',
+                    'client_id': 'api-key',
+                    'client_secret': 'api-secret-key',
+                }
+            ),
+            'utf-8',
+        ),
+    )
+
+    from spylib.oauth import perform_token_exchange
+
+    await perform_token_exchange(
+        code='code',
+        shop=shop,
+        api_key='api-key',
+        api_secret_key='api-secret-key',
+    )


### PR DESCRIPTION
I outlined how I see the utility functions being implemented by partially implementing the `token_exchange` step of oauth. Please provide some feedback to I can move ahead with this - I have to implement it for an app anyway so would like to do it here

Note: I think I found a bug - you cannot import anything from the oauth folder without having fastapi installed because of the import in `__init__`