### PR TITLE
:sparkles: Document versioning 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,13 +45,13 @@ jobs:
         run: |
           source .venv/bin/activate
           lazydocs --overview-file="index.md" --src-base-url="https://github.com/SatelCreative/satel-spylib/tree/main" --output-path="./docs/api-docs" --no-validate spylib
-      - name: Release doc of new version
-      - run: |
-        poetry run mike deploy --push --update-aliases ${RELEASE_VERSION} latest
-      - name: Deploy MkDocs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.24
-        # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXTRA_PACKAGES: build-base
-          REQUIREMENTS: docs/requirements.txt
+      - name: Deployment setup
+        # Use builtin token to deploy
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com 
+      - name: Deploy document
+        run: |
+          echo "RELEASE_TAG_VERSION=${RELEASE_VERSION}"
+          poetry run mike deploy --push --update-aliases ${RELEASE_VERSION} latest
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+        # Config user for mike to push commit
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up python
         uses: actions/setup-python@v2
         with:
@@ -37,6 +45,9 @@ jobs:
         run: |
           source .venv/bin/activate
           lazydocs --overview-file="index.md" --src-base-url="https://github.com/SatelCreative/satel-spylib/tree/main" --output-path="./docs/api-docs" --no-validate spylib
+      - name: Release doc of new version
+      - run: |
+        poetry run mike deploy --push --update-aliases ${RELEASE_VERSION} latest
       - name: Deploy MkDocs
         uses: mhausenblas/mkdocs-deploy-gh-pages@1.24
         # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-        # Config user for mike to push commit
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up python

--- a/docs/development-contributing.md
+++ b/docs/development-contributing.md
@@ -35,9 +35,9 @@ Inside `poetry shell`:
 
 ```bash
 lazydocs --overview-file="index.md" \
---src-base-url="https://github.com/SatelCreative/satel-spylib/tree/main" \
+--src-base-url="https://github.com/SatelCreative/spylib/tree/main" \
 --output-path="./docs/api-docs" \
---validate spylib
+spylib
 
 mkdocs build
 mkdocs serve

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-awesome-pages-plugin==v2.6.0
 mkdocs-material==7.3.6
+mike==1.1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,3 +14,7 @@ plugins:
   - awesome-pages
 markdown_extensions:
 - pymdownx.superfences
+
+extra:
+  version:
+    provider: mike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ lazydocs = "0.4.8"
 pydocstyle = "6.1.1"
 linkcheckmd= "1.4.0"
 respx = "0.19.2"
+mike = "1.1.2"
 
 fastapi = { version = ">= 0.69.0", optional = true }
 

--- a/spylib/multipass.py
+++ b/spylib/multipass.py
@@ -41,7 +41,3 @@ def _pad(s):
     return s + (AES.block_size - len(s) % AES.block_size) * chr(
         AES.block_size - len(s) % AES.block_size
     )
-
-
-def test(a):
-    return a

--- a/spylib/multipass.py
+++ b/spylib/multipass.py
@@ -41,3 +41,7 @@ def _pad(s):
     return s + (AES.block_size - len(s) % AES.block_size) * chr(
         AES.block_size - len(s) % AES.block_size
     )
+
+
+def test(a):
+    return a


### PR DESCRIPTION
close #118 
- Support versioning documentation
- Add step in github action workflow to push versioned document
- Use `fetch-depth: 0` as mentioned in [here](https://github.com/jimporter/mike/issues/49#issuecomment-809552399)
- Remove the step using `Deploy MkDocs` to deploy, as we are using mike, and keep that will remove the versioned docs
- This will auto trigger when new release is made, and create a new drop down according to the version tag
- I have accidently pushed the current 0.6.0 doc to the Github page, so you will be able to see the `0.6.0` dropdown on the top of the Spylib doc
- This screenshot is from a different repo I used to test Github Actions
![Screenshot_20220721_111008](https://user-images.githubusercontent.com/41352240/180284133-31332f2a-0979-440a-9a55-4ce5ed3a2f40.png)
