### PR TITLE
♻️ Fix/remove duplicated token models

### DIFF
--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -31,30 +31,6 @@ from spylib.exceptions import (
 from spylib.utils.rest import Request
 
 
-class AssociatedUser(BaseModel):
-    id: int
-    first_name: str
-    last_name: str
-    email: str
-    email_verified: bool
-    account_owner: bool
-    locale: str
-    collaborator: bool
-
-
-class OfflineTokenResponse(BaseModel):
-    access_token: str
-    scope: str
-
-
-class OnlineTokenResponse(BaseModel):
-    access_token: str
-    scope: str
-    expires_in: int
-    associated_user_scope: str
-    associated_user: AssociatedUser
-
-
 class Token(ABC, BaseModel):
     """
     Abstract class for token objects. This should never be extended, as you

--- a/tests/admin_api/test_initialization.py
+++ b/tests/admin_api/test_initialization.py
@@ -20,7 +20,7 @@ async def test_online_token():
 
     assert online_token.access_token == online_token_data.access_token
     assert not online_token.access_token_invalid
-    assert online_token.scope == online_token_data.scope.split(',')
+    assert online_token.scope == online_token_data.scope
     assert online_token.associated_user_id == online_token_data.associated_user.id
     assert online_token.api_url == (
         f'https://{test_information.store_name}.myshopify.com/admin/'
@@ -38,7 +38,7 @@ async def test_offline_token():
     offline_token = await OfflineToken.load(store_name=test_information.store_name)
 
     assert offline_token.access_token == offline_token_data.access_token
-    assert offline_token.scope == offline_token_data.scope.split(',')
+    assert offline_token.scope == offline_token_data.scope
     assert offline_token.store_name == test_information.store_name
     assert not offline_token.access_token_invalid
     assert offline_token.api_url == (
@@ -57,7 +57,7 @@ async def test_private_token():
     private_token = await PrivateToken.load(store_name=test_information.store_name)
 
     assert private_token.access_token == offline_token_data.access_token
-    assert private_token.scope == offline_token_data.scope.split(',')
+    assert private_token.scope == offline_token_data.scope
     assert private_token.store_name == test_information.store_name
     assert not private_token.access_token_invalid
     assert private_token.api_url == (

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -3,15 +3,10 @@ from __future__ import annotations
 from pydantic.class_validators import validator
 from pydantic.main import BaseModel
 
-from spylib.admin_api import (
-    OfflineTokenABC,
-    OfflineTokenResponse,
-    OnlineTokenABC,
-    OnlineTokenResponse,
-    PrivateTokenABC,
-)
+from spylib.admin_api import OfflineTokenABC, OnlineTokenABC, PrivateTokenABC
+from spylib.oauth.models import OfflineTokenModel, OnlineTokenModel
 
-online_token_data = OnlineTokenResponse(
+online_token_data = OnlineTokenModel(
     access_token='ONLINETOKEN',
     scope=','.join(['write_products', 'read_customers']),
     expires_in=86399,
@@ -28,7 +23,7 @@ online_token_data = OnlineTokenResponse(
     },
 )
 
-offline_token_data = OfflineTokenResponse(
+offline_token_data = OfflineTokenModel(
     access_token='OFFLINETOKEN',
     scope=','.join(['write_products', 'read_customers', 'write_orders']),
 )
@@ -72,9 +67,9 @@ class OnlineToken(OnlineTokenABC):
     async def load(cls, store_name: str, user_id: str) -> OnlineToken:
         return OnlineToken(
             access_token=online_token_data.access_token,
-            scope=online_token_data.scope.split(','),
+            scope=online_token_data.scope,
             associated_user_id=online_token_data.associated_user.id,
-            associated_user_scope=online_token_data.associated_user_scope.split(','),
+            associated_user_scope=online_token_data.associated_user_scope,
             expires_in=online_token_data.expires_in,
             store_name=test_information.store_name,
         )
@@ -88,7 +83,7 @@ class OfflineToken(OfflineTokenABC):
     async def load(cls, store_name: str) -> OfflineToken:
         return OfflineToken(
             access_token=offline_token_data.access_token,
-            scope=offline_token_data.scope.split(','),
+            scope=offline_token_data.scope,
             store_name=test_information.store_name,
         )
 
@@ -98,6 +93,6 @@ class PrivateToken(PrivateTokenABC):
     async def load(cls, store_name: str) -> PrivateToken:
         return PrivateToken(
             access_token=offline_token_data.access_token,
-            scope=offline_token_data.scope.split(','),
+            scope=offline_token_data.scope,
             store_name=test_information.store_name,
         )


### PR DESCRIPTION
fix #132 

- remove the duplicated models in the `admin_api` that's already extracted into `spylib/oauth/models.py` in PR #146 
- fix the associated tests 
