### PR TITLE
🐛 Fix fastapi tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ pydantic ="^1.8.2"
 PyJWT = "^2.1.0"
 pycryptodome = "^3.10.1"
 
+fastapi = { version = ">= 0.69.0", optional = true }
+
 [tool.poetry.dev-dependencies]
 blue = "0.9.0"
 pytest = "6.2.4"
@@ -46,7 +48,6 @@ linkcheckmd= "1.4.0"
 respx = "0.19.2"
 mike = "1.1.2"
 
-fastapi = { version = ">= 0.69.0", optional = true }
 
 [tool.poetry.extras]
 fastapi = ["fastapi"]

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -63,8 +63,9 @@ class MockHTTPResponse:
 
 @pytest.mark.asyncio
 async def test_oauth_without_fastapi():
-    with pytest.raises(FastAPIImportError):
-        import spylib.oauth.fastapi  # noqa: F401
+    if 'fastapi' not in modules and util.find_spec('fastapi') is None:
+        with pytest.raises(FastAPIImportError):
+            import spylib.oauth.fastapi  # noqa: F401
 
 
 @pytest.mark.asyncio
@@ -75,7 +76,8 @@ async def test_oauth_with_fastapi(mocker):
     from fastapi import FastAPI  # type: ignore[import]
     from fastapi.testclient import TestClient  # type: ignore[import]
 
-    from spylib.oauth import OfflineToken, OnlineToken, init_oauth_router
+    from spylib.oauth import OfflineTokenModel, OnlineTokenModel
+    from spylib.oauth.fastapi import init_oauth_router
 
     app = FastAPI()
 
@@ -142,7 +144,7 @@ async def test_oauth_with_fastapi(mocker):
     )
 
     TEST_DATA.post_install.assert_called_once()
-    TEST_DATA.post_install.assert_called_with('test', OfflineToken(**OFFLINETOKEN_DATA))
+    TEST_DATA.post_install.assert_called_with('test', OfflineTokenModel(**OFFLINETOKEN_DATA))
 
     # --------- Test the callback endpoint for login -----------
     query_str = urlencode(
@@ -171,7 +173,7 @@ async def test_oauth_with_fastapi(mocker):
     )
 
     TEST_DATA.post_login.assert_called_once()
-    TEST_DATA.post_login.assert_called_with('test', OnlineToken(**ONLINETOKEN_DATA))
+    TEST_DATA.post_login.assert_called_with('test', OnlineTokenModel(**ONLINETOKEN_DATA))
 
 
 def check_oauth_redirect_url(response: Response, client, path: str, scope: List[str]) -> str:


### PR DESCRIPTION
**Issue:** the CICD never ran the tests with `fastapi` installed because it's put in the dev-dependencies section in the `pyproject.toml` file and command `poetry install -E fastapi` wouldn't install it. 

**Fix:** move the `fastapi` to dependencies from dev-dependencies section and fix the broken tests