### PR TITLE
🎨 add bytes type data support to webhook hmac validate function

### DIFF
--- a/spylib/constants.py
+++ b/spylib/constants.py
@@ -23,3 +23,4 @@ OPERATION_NAME_REQUIRED_ERROR_MESSAGE = 'An operation name is required'
 WRONG_OPERATION_NAME_ERROR_MESSAGE = (
     'No operation named "{}"'  # Required as they don't stay consistant
 )
+UTF8ENCODING = 'utf-8'

--- a/spylib/webhook/__init__.py
+++ b/spylib/webhook/__init__.py
@@ -25,12 +25,15 @@ class WebhookCreate(Enum):
 
 
 def validate(data: Union[str, bytes], hmac_header: str, api_secret_key: str) -> bool:
+    data_str: str
     if isinstance(data, bytes):
-        data_str: str = data.decode(UTF8ENCODING)
+        data_str = data.decode(UTF8ENCODING)
     else:
-        data_str: str = data
+        data_str = data
     try:
-        validate_hmac(secret=api_secret_key, sent_hmac=hmac_header, message=data_str, use_base64=True)
+        validate_hmac(
+            secret=api_secret_key, sent_hmac=hmac_header, message=data_str, use_base64=True
+        )
     except ValueError:
         return False
     return True

--- a/spylib/webhook/__init__.py
+++ b/spylib/webhook/__init__.py
@@ -26,9 +26,11 @@ class WebhookCreate(Enum):
 
 def validate(data: Union[str, bytes], hmac_header: str, api_secret_key: str) -> bool:
     if isinstance(data, bytes):
-        data = data.decode(UTF8ENCODING)
+        data_str: str = data.decode(UTF8ENCODING)
+    else:
+        data_str: str = data
     try:
-        validate_hmac(secret=api_secret_key, sent_hmac=hmac_header, message=data, use_base64=True)
+        validate_hmac(secret=api_secret_key, sent_hmac=hmac_header, message=data_str, use_base64=True)
     except ValueError:
         return False
     return True

--- a/spylib/webhook/__init__.py
+++ b/spylib/webhook/__init__.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Union
 from pydantic import BaseModel
 
 from spylib.admin_api import OfflineTokenABC
+from spylib.constants import UTF8ENCODING
 from spylib.exceptions import ShopifyGQLUserError
 from spylib.hmac import validate as validate_hmac
 from spylib.webhook.graphql_queries import WEBHOOK_CREATE_GQL
@@ -23,7 +24,9 @@ class WebhookCreate(Enum):
     PUB_SUB = 'pubSubWebhookSubscriptionCreate'
 
 
-def validate(data: str, hmac_header: str, api_secret_key: str) -> bool:
+def validate(data: Union[str, bytes], hmac_header: str, api_secret_key: str) -> bool:
+    if isinstance(data, bytes):
+        data = data.decode(UTF8ENCODING)
     try:
         validate_hmac(secret=api_secret_key, sent_hmac=hmac_header, message=data, use_base64=True)
     except ValueError:

--- a/tests/test_webhook_verification.py
+++ b/tests/test_webhook_verification.py
@@ -2,6 +2,7 @@ import pytest
 from pytest import param
 
 from spylib import webhook
+from spylib.constants import UTF8ENCODING
 
 API_SECRET = 'secret'
 MESSAGE = 'message'
@@ -10,6 +11,13 @@ INVALID_HMAC = 'hmac'
 
 params = [
     param(API_SECRET, MESSAGE, VALID_HMAC, True, id='hmac is valid'),
+    param(
+        API_SECRET,
+        bytes(MESSAGE, UTF8ENCODING),
+        VALID_HMAC,
+        True,
+        id='hmac is valid with data in bytes',
+    ),
     param(API_SECRET, MESSAGE, INVALID_HMAC, False, id='hmac is invalid'),
 ]
 


### PR DESCRIPTION
fix #164 

change webhook validate function to support both `str` or `bytes` data input 
from
```py
validate(data: str, hmac_header: str, api_secret_key: str)
```
to 
```py
validate(data: Union[str, bytes], hmac_header: str, api_secret_key: str)
```