### PR TITLE
🐛 add 10 seconds leeway for session token check on the nbf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ pydantic ="^1.8.2"
 PyJWT = "^2.1.0"
 pycryptodome = "^3.10.1"
 
-fastapi = { version = ">= 0.69.0", optional = true }
+fastapi = { version = ">= 0.69.0 < 0.87.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 blue = "0.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/SatelCreative/spylib"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-httpx = ">= 0.18.1"
+httpx = ">= 0.18.1 < 0.23.1"
 tenacity = "^7.0.0"
 starlette = ">= 0.15.0"
 nest-asyncio = "^1.5.1"

--- a/spylib/session_token.py
+++ b/spylib/session_token.py
@@ -13,6 +13,7 @@ from .utils.domain import store_domain
 REQUIRED_FIELDS = ['iss', 'dest', 'sub', 'jti', 'sid']
 ALGORITHM = 'HS256'
 PREFIX = 'Bearer '
+LEEWAY_SECONDS = 10
 
 
 class TokenValidationError(Exception):
@@ -83,6 +84,9 @@ class SessionToken(BaseModel):
             secret,
             audience=api_key,
             algorithms=[ALGORITHM],
+            # AppBridge frequently sends future `nbf`, and it causes `ImmatureSignatureError`.
+            # Accept few seconds clock skew to avoid this error.
+            leeway=LEEWAY_SECONDS,
             options={'require': REQUIRED_FIELDS},
         )
 


### PR DESCRIPTION


encountering the following `ImmatureSignatureError` from time to time when doing the end to end test with the PIM client.
```
webapp_1   |   File "/python/app/./middleware/session_token.py", line 47, in __call__
webapp_1   |     session = SessionToken.from_header(headers.get('Authorization'), self.api_key, self.secret)
webapp_1   |   File "/home/python/lib/python3.9/site-packages/spylib/session_token.py", line 81, in from_header
webapp_1   |     payload = decode(
webapp_1   |   File "/home/python/lib/python3.9/site-packages/jwt/api_jwt.py", line 119, in decode
webapp_1   |     decoded = self.decode_complete(jwt, key, algorithms, options, **kwargs)
webapp_1   |   File "/home/python/lib/python3.9/site-packages/jwt/api_jwt.py", line 106, in decode_complete
webapp_1   |     self._validate_claims(payload, merged_options, **kwargs)
webapp_1   |   File "/home/python/lib/python3.9/site-packages/jwt/api_jwt.py", line 139, in _validate_claims
webapp_1   |     self._validate_nbf(payload, now, leeway)
webapp_1   |   File "/home/python/lib/python3.9/site-packages/jwt/api_jwt.py", line 168, in _validate_nbf
webapp_1   |     raise ImmatureSignatureError("The token is not yet valid (nbf)")
webapp_1   | jwt.exceptions.ImmatureSignatureError: The token is not yet valid (nbf)
```

did a bit googling and found that's an existing issue others encountered as well
ref: [Session_token Gives Me Error "The Token Is Not Yet Valid (Nbc)"](https://community.shopify.com/c/shopify-apps/session-token-gives-me-error-quot-the-token-is-not-yet-valid-nbc/td-p/1505387)
and the shopify python library has it fixed with the [leeway](https://github.com/jpadilla/pyjwt/blob/master/jwt/api_jwt.py#L238-L245) that applies to `nbf`, `exp`, `iat`:
[Accept 10 seconds clock skew to avoid ImmatureSignatureError](https://github.com/Shopify/shopify_python_api/pull/609)

The solution is applied here as well. 