### PR TITLE
:white_check_mark: Add some oauth tests

### DIFF
--- a/spylib/oauth/exchange_token.py
+++ b/spylib/oauth/exchange_token.py
@@ -109,6 +109,6 @@ async def exchange_online_token(
         shop=shop, code=code, api_key=api_key, api_secret_key=api_secret_key
     )
 
-    assert isinstance(token, OnlineTokenModel)
+    assert isinstance(token, OnlineTokenModel), "Access token obtained is not an online token"
 
     return token

--- a/spylib/oauth/fastapi.py
+++ b/spylib/oauth/fastapi.py
@@ -85,7 +85,7 @@ def init_oauth_router(
                 post_login=post_login,
             )
         except Exception as e:
-            raise HTTPException(status_code=400, detail=f'Validation failed: {e}')
+            raise HTTPException(status_code=400, detail=f'Validation failed: {str(e)}')
 
         # === If installation ===
         # Setup the login obj and redirect to oauth_redirect


### PR DESCRIPTION
I ran into a bug when I tried to use spylib with the latest version and the oauth process. I thought it was because of an additional `host` query parameter but after adding tests, it doesn't seem to be a problem!  :persevere: 

So either my test is not correct, or I'm looking in the wrong place.  :confused: 
In the meantime I can commit the tests.