### PR TITLE
:sparkles: Remove default API version and make it manual input

### DIFF
--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -42,7 +42,7 @@ class Token(ABC, BaseModel):
     access_token: Optional[str]
     access_token_invalid: bool = False
 
-    api_version: ClassVar[str] = '2022-01'
+    api_version: ClassVar[str] = ''
 
     rest_bucket_max: int = 80
     rest_bucket: int = rest_bucket_max
@@ -62,6 +62,8 @@ class Token(ABC, BaseModel):
 
     @property
     def api_url(self) -> str:
+        if not self.api_version:
+            return f'https://{self.store_name}.myshopify.com/admin'
         return f'https://{self.store_name}.myshopify.com/admin/api/{self.api_version}'
 
     @validator('scope', pre=True)

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -37,12 +37,12 @@ class Token(ABC, BaseModel):
     should either be using the OfflineTokenABC or the OnlineTokenABC.
     """
 
-    api_version: ClassVar[Optional[str]] = None
-
     store_name: str
     scope: List[str] = []
     access_token: Optional[str]
     access_token_invalid: bool = False
+
+    api_version: ClassVar[Optional[str]] = None
 
     rest_bucket_max: int = 80
     rest_bucket: int = rest_bucket_max

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -37,6 +37,8 @@ class Token(ABC, BaseModel):
     should either be using the OfflineTokenABC or the OnlineTokenABC.
     """
 
+    api_version: ClassVar[Optional[str]] = None
+
     store_name: str
     scope: List[str] = []
     access_token: Optional[str]
@@ -60,7 +62,9 @@ class Token(ABC, BaseModel):
 
     @property
     def api_url(self) -> str:
-        return f'https://{self.store_name}.myshopify.com/admin'
+        if not self.api_version:
+            return f'https://{self.store_name}.myshopify.com/admin'
+        return f'https://{self.store_name}.myshopify.com/admin/api/{self.api_version}'
 
     @validator('scope', pre=True)
     def convert_scope(cls, v):
@@ -121,7 +125,6 @@ class Token(ABC, BaseModel):
         self,
         request: Request,
         endpoint: str,
-        api_version: Optional[str] = None,
         json: Optional[Dict[str, Any]] = None,
         debug: str = '',
     ) -> Dict[str, Any]:
@@ -131,13 +134,9 @@ class Token(ABC, BaseModel):
             if not self.access_token:
                 raise ValueError('You have not initialized the token for this store. ')
 
-            url = f'{self.api_url}{endpoint}'
-            if api_version:
-                url = f'{self.api_url}/api/{api_version}{endpoint}'
-
             response = await self.client.request(
                 method=request.method.value,
-                url=url,
+                url=f'{self.api_url}{endpoint}',
                 headers={'X-Shopify-Access-Token': self.access_token},
                 json=json,
             )
@@ -168,7 +167,6 @@ class Token(ABC, BaseModel):
         self,
         query: str,
         variables: Dict[str, Any] = {},
-        api_version: Optional[str] = None,
         operation_name: Optional[str] = None,
         suppress_errors: bool = False,
     ) -> Dict[str, Any]:
@@ -177,8 +175,6 @@ class Token(ABC, BaseModel):
             raise ValueError('Token Undefined')
 
         url = f'{self.api_url}/graphql.json'
-        if api_version:
-            url = f'{self.api_url}/api/{api_version}/graphql.json'
 
         headers = {
             'Content-type': 'application/json',

--- a/tests/admin_api/test_initialization.py
+++ b/tests/admin_api/test_initialization.py
@@ -4,6 +4,7 @@ from ..token_classes import (
     OfflineToken,
     OnlineToken,
     PrivateToken,
+    VersionOfflineToken,
     offline_token_data,
     online_token_data,
     test_information,
@@ -58,4 +59,19 @@ async def test_private_token():
     assert (
         private_token.oauth_url
         == f'https://{test_information.store_name}.myshopify.com/admin/oauth/access_token'
+    )
+
+
+@pytest.mark.asyncio
+async def test_version_offline_token():
+    offline_token = await VersionOfflineToken.load(store_name=test_information.store_name)
+    print(offline_token.api_version)
+
+    assert offline_token.access_token == offline_token_data.access_token
+    assert offline_token.scope == offline_token_data.scope
+    assert offline_token.store_name == test_information.store_name
+    assert not offline_token.access_token_invalid
+    assert (
+        offline_token.api_url
+        == f'https://{test_information.store_name}.myshopify.com/admin/api/2023-04'
     )

--- a/tests/admin_api/test_initialization.py
+++ b/tests/admin_api/test_initialization.py
@@ -22,10 +22,7 @@ async def test_online_token():
     assert not online_token.access_token_invalid
     assert online_token.scope == online_token_data.scope
     assert online_token.associated_user_id == online_token_data.associated_user.id
-    assert online_token.api_url == (
-        f'https://{test_information.store_name}.myshopify.com/admin/'
-        + f'api/{test_information.api_version}'
-    )
+    assert online_token.api_url == f'https://{test_information.store_name}.myshopify.com/admin'
     assert (
         online_token.oauth_url
         == f'https://{test_information.store_name}.myshopify.com/admin/oauth/access_token'
@@ -41,10 +38,7 @@ async def test_offline_token():
     assert offline_token.scope == offline_token_data.scope
     assert offline_token.store_name == test_information.store_name
     assert not offline_token.access_token_invalid
-    assert offline_token.api_url == (
-        f'https://{test_information.store_name}.myshopify.com/admin/'
-        + f'api/{test_information.api_version}'
-    )
+    assert offline_token.api_url == f'https://{test_information.store_name}.myshopify.com/admin'
     assert (
         offline_token.oauth_url
         == f'https://{test_information.store_name}.myshopify.com/admin/oauth/access_token'
@@ -60,10 +54,7 @@ async def test_private_token():
     assert private_token.scope == offline_token_data.scope
     assert private_token.store_name == test_information.store_name
     assert not private_token.access_token_invalid
-    assert private_token.api_url == (
-        f'https://{test_information.store_name}.myshopify.com/admin/'
-        + f'api/{test_information.api_version}'
-    )
+    assert private_token.api_url == f'https://{test_information.store_name}.myshopify.com/admin'
     assert (
         private_token.oauth_url
         == f'https://{test_information.store_name}.myshopify.com/admin/oauth/access_token'

--- a/tests/admin_api/test_initialization.py
+++ b/tests/admin_api/test_initialization.py
@@ -65,13 +65,8 @@ async def test_private_token():
 @pytest.mark.asyncio
 async def test_version_offline_token():
     offline_token = await VersionOfflineToken.load(store_name=test_information.store_name)
-    print(offline_token.api_version)
-
-    assert offline_token.access_token == offline_token_data.access_token
-    assert offline_token.scope == offline_token_data.scope
-    assert offline_token.store_name == test_information.store_name
-    assert not offline_token.access_token_invalid
     assert (
         offline_token.api_url
-        == f'https://{test_information.store_name}.myshopify.com/admin/api/2023-04'
+        == f'https://{test_information.store_name}'
+        + f'.myshopify.com/admin/api/{test_information.api_version}'
     )

--- a/tests/admin_api/test_initialization.py
+++ b/tests/admin_api/test_initialization.py
@@ -65,6 +65,7 @@ async def test_private_token():
 @pytest.mark.asyncio
 async def test_version_offline_token():
     offline_token = await VersionOfflineToken.load(store_name=test_information.store_name)
+    assert offline_token.api_version == test_information.api_version
     assert (
         offline_token.api_url
         == f'https://{test_information.store_name}'

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import ClassVar, Optional
+
 from pydantic.class_validators import validator
 from pydantic.main import BaseModel
 
@@ -92,6 +94,21 @@ class PrivateToken(PrivateTokenABC):
     @classmethod
     async def load(cls, store_name: str) -> PrivateToken:
         return PrivateToken(
+            access_token=offline_token_data.access_token,
+            scope=offline_token_data.scope,
+            store_name=test_information.store_name,
+        )
+
+
+class VersionOfflineToken(OfflineTokenABC):
+    api_version: ClassVar[Optional[str]] = '2023-04'
+
+    async def save(self):
+        pass
+
+    @classmethod
+    async def load(cls, store_name: str) -> VersionOfflineToken:
+        return VersionOfflineToken(
             access_token=offline_token_data.access_token,
             scope=offline_token_data.scope,
             store_name=test_information.store_name,

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -101,7 +101,7 @@ class PrivateToken(PrivateTokenABC):
 
 
 class VersionOfflineToken(OfflineTokenABC):
-    api_version: ClassVar[Optional[str]] = '2023-04'
+    api_version: ClassVar[Optional[str]] = test_information.api_version
 
     async def save(self):
         pass

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -49,7 +49,7 @@ class TestInformation(BaseModel):
     Information about the store for tests.
     """
 
-    api_version: str = '2022-01'
+    api_version: str = '2023-04'
     store_name: str = 'Test-Store'
     client_id: int = 1
     client_secret: int = 2


### PR DESCRIPTION
- Remove the `api_version` in `Token`, I couldn't found a way to override the field value
- Let `api_version` be input in `execute_rest` and `execute_gql`, since we construct full url inside the function
- If no version is entered, default to `/admin` which the oldest supported version will be used
- Modify test

close #173 
