### PR TITLE
:alien: 💥  replace app_handle with app_api_key for redirect

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -31,7 +31,6 @@ oauth_router = init_oauth_router(
     private_key='KEY_FOR_OAUTH_JWT',
     api_key='SHOPIFY_APP_API_KEY',
     api_secret_key='SHOPIFY_APP_SECRET_KEY',
-    app_handle='SHOPIFY_APP_HANDLE',
     post_install=my_post_install,
     post_login=my_post_login,
     install_init_path='/install_path',
@@ -48,11 +47,7 @@ mechanism to track the `nonce`. This JWT has an expiration time and is unique fo
 OAuth process making it a valid `nonce` mechanism.
 The `private_key` parameter defines the key used to encode and decode this JWT.
 
-The api and secret key can be found inside your shopify app main configuration page. The
-app handle can be found in the same spot but needs to be pulled from the url:
-
-1. Go to your shopify app's editing page (The url should be `https://partners.shopify.com/<partner_id>/apps/<app_id>/edit`)
-2. Open the console and run `window.RailsData.user.app.handle`. The result is the handle.
+The api and secret key can be found inside your shopify app main configuration page.
 
 The `post_install` and `post_login` provide a way to inject functions handling the
 result of the installation and the login processes respectivaly. They are meant in

--- a/spylib/oauth/fastapi.py
+++ b/spylib/oauth/fastapi.py
@@ -34,7 +34,6 @@ def init_oauth_router(
     user_scopes: List[str],
     public_domain: str,
     private_key: str,
-    app_handle: str,
     api_key: str,
     api_secret_key: str,
     post_install: Callable[[str, OfflineTokenModel], Optional[Awaitable]],
@@ -95,7 +94,7 @@ def init_oauth_router(
                     app_redirect(
                         store_domain=args.shop,
                         app_domain=public_domain,
-                        app_handle=app_handle,
+                        app_api_key=api_key,
                     )
                 )
             # Initiate the oauth loop for login
@@ -117,7 +116,7 @@ def init_oauth_router(
             app_redirect(
                 store_domain=args.shop,
                 app_domain=public_domain,
-                app_handle=app_handle,
+                app_api_key=api_key,
             )
         )
 

--- a/spylib/oauth/redirects.py
+++ b/spylib/oauth/redirects.py
@@ -46,7 +46,7 @@ def oauth_init_url(
 def app_redirect(
     store_domain: str,
     app_domain: str,
-    app_handle: str,
+    app_api_key: str,
 ) -> str:
 
-    return f'https://{store_domain}/admin/apps/{app_handle}'
+    return f'https://{store_domain}/admin/apps/{app_api_key}'

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -69,7 +69,7 @@ async def test_oauth_without_fastapi():
 @pytest.mark.asyncio
 async def test_oauth_with_fastapi(mocker):
     if 'fastapi' not in modules and util.find_spec('fastapi') is None:
-        pytest.skip("fastapi not installed")
+        pytest.skip('fastapi not installed')
 
     from fastapi import FastAPI  # type: ignore[import]
     from fastapi.testclient import TestClient  # type: ignore[import]

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -69,7 +69,7 @@ async def test_oauth_without_fastapi():
 @pytest.mark.asyncio
 async def test_oauth_with_fastapi(mocker):
     if 'fastapi' not in modules and util.find_spec('fastapi') is None:
-        return
+        pytest.skip("fastapi not installed")
 
     from fastapi import FastAPI  # type: ignore[import]
     from fastapi.testclient import TestClient  # type: ignore[import]

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -13,7 +13,6 @@ from spylib import hmac
 from spylib.exceptions import FastAPIImportError
 from spylib.utils import JWTBaseModel, now_epoch
 
-HANDLE = 'HANDLE'
 SHOPIFY_API_KEY = 'API_KEY'
 SHOPIFY_SECRET_KEY = 'SECRET_KEY'
 
@@ -26,7 +25,6 @@ TEST_DATA = Box(
         private_key='TESTPRIVATEKEY',
         post_install=AsyncMock(return_value=JWTBaseModel()),
         post_login=AsyncMock(return_value=None),
-        app_handle=HANDLE,
         api_key=SHOPIFY_API_KEY,
         api_secret_key=SHOPIFY_SECRET_KEY,
     )
@@ -158,7 +156,7 @@ async def test_oauth_with_fastapi(mocker):
     state = check_oauth_redirect_url(
         response=response,
         client=client,
-        path=f'/admin/apps/{HANDLE}',
+        path=f'/admin/apps/{SHOPIFY_API_KEY}',
         scope=TEST_DATA.user_scopes,
     )
 


### PR DESCRIPTION
close #181 

Do we want to also support redirect to non emebeded app like doing below?

```python
def app_redirect(
    store_domain: str, app_domain: str, app_api_key: str, embedded: bool = True
) -> str:
    if not embedded:
        return f'https://{app_domain}'
    return f'https://{store_domain}/admin/apps/{app_api_key}'
```