### PR TITLE
:memo: Fix the link to point to the latest docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
-Please read the [Development - Contributing](https://satelcreative.github.io/spylib/development-contributing/)
+Please read the [Development - Contributing](https://satelcreative.github.io/spylib/latest/development-contributing/)
 guidelines in the documentation site.


### PR DESCRIPTION
This will fix the issue mentioned in this [other PR](https://github.com/SatelCreative/spylib/pull/194#discussion_r1264027372)