### PR TITLE
:bug: Handle when the a Shopify API call response body is not a json

### DIFF
--- a/spylib/constants.py
+++ b/spylib/constants.py
@@ -1,26 +1,13 @@
-"""These are the text error codes thrown by the GraphQL API.
-
-Although some errors throw a code e.g.
-
-    "errors": [
-        {
-            "message": "Throttled",
-            "extensions": {
-                "code": "THROTTLED"
-            }
-        }
-
-Not all provide the `code` parameter. Although you could just handle errors
-based on the message, this becomes very difficult as some of the messages
-are very long (see the max_cost_exceeded error output, which is ~350 characters)
-"""
-
-# Error Codes
+# Shopify GraphQL error Codes
+# https://shopify.dev/api/admin-graphql#status_and_error_codes
 THROTTLED_ERROR_CODE = 'THROTTLED'
 MAX_COST_EXCEEDED_ERROR_CODE = 'MAX_COST_EXCEEDED'
+
 # Error Messages
 OPERATION_NAME_REQUIRED_ERROR_MESSAGE = 'An operation name is required'
 WRONG_OPERATION_NAME_ERROR_MESSAGE = (
     'No operation named "{}"'  # Required as they don't stay consistant
 )
+
 UTF8ENCODING = 'utf-8'
+API_CALL_NUMBER_RETRY_ATTEMPTS = 5

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -16,6 +16,17 @@ class ShopifyGQLUserError(Exception):
     pass
 
 
+class ShopifyInvalidResponseBody(ShopifyError):
+    """Exception to identify the rare and weird case when Shopify returned body is not the expected
+    type, typically not a JSON.
+
+    These should be retried because they are intermittent and most likely and internal error in
+    Shopify that wasn't handled properly.
+    """
+
+    pass
+
+
 class ShopifyCallInvalidError(ShopifyError):
     """Exception to identify errors that our due to bad data sent by us.
 

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -17,11 +17,10 @@ class ShopifyGQLUserError(Exception):
 
 
 class ShopifyInvalidResponseBody(ShopifyError):
-    """Exception to identify the rare and weird case when Shopify returned body is not the expected
-    type, typically not a JSON.
+    """Exception to identify when Shopify returned body is not the expected type, i.e. not a JSON.
 
-    These should be retried because they are intermittent and most likely and internal error in
-    Shopify that wasn't handled properly.
+    These seem extremely rare and should be retried because they are intermittent and most likely
+    and internal error in Shopify that wasn't handled properly.
     """
 
     pass

--- a/tests/admin_api/test_graphql_errors.py
+++ b/tests/admin_api/test_graphql_errors.py
@@ -1,14 +1,34 @@
 from unittest.mock import AsyncMock
 
-import pytest
+from pytest import mark, param, raises
 
-from spylib.exceptions import ShopifyGQLError
+from spylib.constants import API_CALL_NUMBER_RETRY_ATTEMPTS
+from spylib.exceptions import ShopifyGQLError, ShopifyInvalidResponseBody
 
 from ..token_classes import MockHTTPResponse, OfflineToken, test_information
 
+NO_RETRY_ATTEMPTS = 1
 
-@pytest.mark.asyncio
-async def test_store_graphql_surface_errors(mocker):
+
+scenarios = [
+    param(
+        dict(status_code=200, jsondata={'data': {}, 'errors': [{'message': 'any error'}]}),
+        NO_RETRY_ATTEMPTS,
+        ShopifyGQLError,
+        id='Any error message from GraphQL',
+    ),
+    param(
+        dict(status_code=200, jsondata=None),
+        API_CALL_NUMBER_RETRY_ATTEMPTS,
+        ShopifyInvalidResponseBody,
+        id='Weird Shopify intermittent error returning HTML instead of a JSON in the response body',
+    ),
+]
+
+
+@mark.asyncio
+@mark.parametrize('gql_response, number_attempts, expected_exception', scenarios)
+async def test_store_graphql_surface_errors(gql_response, number_attempts, expected_exception, mocker):
     token = await OfflineToken.load(store_name=test_information.store_name)
 
     query = """
@@ -18,14 +38,12 @@ async def test_store_graphql_surface_errors(mocker):
       }
     }"""
 
-    gql_response = {'data': {}, 'errors': [{'message': 'any error'}]}
-
     shopify_request_mock = mocker.patch(
         'httpx.AsyncClient.request',
         new_callable=AsyncMock,
-        return_value=MockHTTPResponse(status_code=200, jsondata=gql_response),
+        return_value=MockHTTPResponse(**gql_response),
     )
-    with pytest.raises(ShopifyGQLError):
+    with raises(expected_exception):
         await token.execute_gql(query=query, suppress_errors=False)
 
-    assert shopify_request_mock.call_count == 1
+    assert shopify_request_mock.call_count == number_attempts

--- a/tests/admin_api/test_graphql_errors.py
+++ b/tests/admin_api/test_graphql_errors.py
@@ -28,7 +28,9 @@ scenarios = [
 
 @mark.asyncio
 @mark.parametrize('gql_response, number_attempts, expected_exception', scenarios)
-async def test_store_graphql_surface_errors(gql_response, number_attempts, expected_exception, mocker):
+async def test_store_graphql_surface_errors(
+    gql_response, number_attempts, expected_exception, mocker
+):
     token = await OfflineToken.load(store_name=test_information.store_name)
 
     query = """

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from json import loads
 from typing import ClassVar, Optional
 
 from pydantic.class_validators import validator
@@ -33,14 +34,17 @@ offline_token_data = OfflineTokenModel(
 
 class MockHTTPResponse(BaseModel):
     status_code: int
-    jsondata: dict
-    headers: dict = None  # type: ignore
+    jsondata: Optional[dict] = None
+    headers: Optional[dict] = None
 
     @validator('headers', pre=True, always=True)
     def set_id(cls, fld):
         return fld or {'X-Shopify-Shop-Api-Call-Limit': '39/40'}
 
     def json(self):
+        # Mock trying to deserialize something that's not a valid JSON
+        if self.jsondata is None:
+            loads('NOT A JSON')
         return self.jsondata
 
 


### PR DESCRIPTION
We have recently observed a weird response from Shopify that was not a JSON despite the GraphQL status code call being 200.
This ought to be an intermittent error on Shopify's side so we should retry the call to hopefully pass the problem.

I took the opportunity to parameterize the GraphQL error tests so I could add this case.
I also moved the number of retry attempts to a constant since it was in two locations.