### PR TITLE
⬆️ Upgrade to pydantic 2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,6 @@ mike = "1.1.2"
 [tool.poetry.extras]
 fastapi = ["fastapi"]
 
-[tool.poetry.group.dev.dependencies]
-bump-pydantic = "^0.7.0"
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ python = "^3.8"
 httpx = ">= 0.18.1 <= 0.24.1"
 tenacity = "^8.2.2"
 starlette = ">= 0.15.0"
-pydantic ="^1.8.2"
+pydantic = "^2.5.2"
 PyJWT = "^2.1.0"
 pycryptodome = "^3.10.1"
 
-fastapi = { version = ">= 0.69.0 < 0.100.0", optional = true }
+fastapi = { version = ">= 0.100.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 blue = "0.9.1"
@@ -50,6 +50,9 @@ mike = "1.1.2"
 
 [tool.poetry.extras]
 fastapi = ["fastapi"]
+
+[tool.poetry.group.dev.dependencies]
+bump-pydantic = "^0.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -8,7 +8,7 @@ from time import monotonic
 from typing import Any, ClassVar, Dict, List, Optional
 
 from httpx import AsyncClient, Response
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from starlette import status
 from tenacity import retry
 from tenacity.retry import retry_if_exception, retry_if_exception_type
@@ -43,7 +43,7 @@ class Token(ABC, BaseModel):
 
     store_name: str
     scope: List[str] = []
-    access_token: Optional[str]
+    access_token: Optional[str] = None
     access_token_invalid: bool = False
 
     api_version: ClassVar[Optional[str]] = None
@@ -70,16 +70,13 @@ class Token(ABC, BaseModel):
             return f'https://{self.store_name}.myshopify.com/admin'
         return f'https://{self.store_name}.myshopify.com/admin/api/{self.api_version}'
 
-    @validator('scope', pre=True)
+    @field_validator('scope', mode="before")
+    @classmethod
     def convert_scope(cls, v):
         if type(v) == str:
             return v.split(',')
         return v
-
-    class Config:
-        """Configure Token model behaviour."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     # Methods for querying the store
 

--- a/spylib/oauth/exchange_token.py
+++ b/spylib/oauth/exchange_token.py
@@ -46,9 +46,9 @@ async def exchange_token(
     is_online_token = 'associated_user' in raw_response_body
 
     if is_online_token:
-        return OnlineTokenModel.parse_obj(raw_response_body)
+        return OnlineTokenModel.model_validate(raw_response_body)
 
-    return OfflineTokenModel.parse_obj(raw_response_body)
+    return OfflineTokenModel.model_validate(raw_response_body)
 
 
 async def exchange_offline_token(

--- a/spylib/oauth/models.py
+++ b/spylib/oauth/models.py
@@ -1,10 +1,8 @@
-from typing import List
+from typing import Annotated, List
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, BeforeValidator
 
-
-def _parse_scope(scope: str) -> List[str]:
-    return scope.split(',')
+from spylib.utils.misc import parse_scope
 
 
 class OfflineTokenModel(BaseModel):
@@ -15,12 +13,10 @@ class OfflineTokenModel(BaseModel):
     An API access token that can be used to access the shop's data as long as your app is installed. Your app should store the token somewhere to make authenticated requests for a shop’s data.
     """
 
-    scope: List[str]
+    scope: Annotated[List[str], BeforeValidator(parse_scope)]
     """
     The list of access scopes that were granted to your app and are associated with the access token.
     """
-
-    _normalize_scope = validator('scope', allow_reuse=True, pre=True)(_parse_scope)
 
 
 class AssociatedUser(BaseModel):
@@ -77,19 +73,14 @@ class OnlineTokenModel(BaseModel):
     access_token: str
     """An API access token that can be used to access the shop's data until it expires or the associated user logs out."""
 
-    scope: List[str]
+    scope: Annotated[List[str], BeforeValidator(parse_scope)]
     """The list of access scopes that were requested. Inspect `associated_user_scope` to see which were granted."""
 
     expires_in: int
     """The number of seconds until this session (and `access_token`) expire."""
 
-    associated_user_scope: List[str]
+    associated_user_scope: Annotated[List[str], BeforeValidator(parse_scope)]
     """The list of access scopes that were both requested and available to this user."""
 
     associated_user: AssociatedUser
     """The Shopify user associated with this token."""
-
-    _normalize_scope = validator('scope', allow_reuse=True, pre=True)(_parse_scope)
-    _normalize_associated_user_scope = validator(
-        'associated_user_scope', allow_reuse=True, pre=True
-    )(_parse_scope)

--- a/spylib/session_token.py
+++ b/spylib/session_token.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 from jwt import decode
-from pydantic import root_validator
+from pydantic import model_validator
 from pydantic.main import BaseModel
 from pydantic.networks import HttpUrl
 
@@ -41,15 +41,16 @@ class SessionToken(BaseModel):
 
     iss: HttpUrl
     dest: HttpUrl
-    aud: Optional[str]
+    aud: Optional[str] = None
     sub: int
-    exp: Optional[float]
-    nbf: Optional[float]
-    iat: Optional[float]
+    exp: Optional[float] = None
+    nbf: Optional[float] = None
+    iat: Optional[float] = None
     jti: str
     sid: str
 
-    @root_validator()
+    @model_validator()
+    @classmethod
     def equal_iss_and_dest(cls, values: Dict[str, Any]):
         domain = cls.__url_to_base(values.get('iss'))
         try:

--- a/spylib/session_token.py
+++ b/spylib/session_token.py
@@ -92,7 +92,7 @@ class SessionToken(BaseModel):
         )
 
         # Verify enough fields specified and perform validation checks
-        return cls.parse_obj(payload)
+        return cls.model_validate(payload)
 
     @staticmethod
     def __url_to_base(url):

--- a/spylib/session_token.py
+++ b/spylib/session_token.py
@@ -33,7 +33,7 @@ class TokenAuthenticationError(TokenValidationError):
 
 
 class SessionToken(BaseModel):
-    """Session tokens are derived from the authrization header from Shopify.
+    """Session tokens are derived from the authorization header from Shopify.
 
     This performs the set of validations as defined by shopify
     https://shopify.dev/apps/auth/session-tokens/authenticate-an-embedded-app-using-session-tokens#obtain-session-details-manually
@@ -49,7 +49,7 @@ class SessionToken(BaseModel):
     jti: str
     sid: str
 
-    @model_validator()
+    @model_validator(mode='before')
     @classmethod
     def equal_iss_and_dest(cls, values: Dict[str, Any]):
         domain = cls.__url_to_base(values.get('iss'))

--- a/spylib/utils/jwtoken.py
+++ b/spylib/utils/jwtoken.py
@@ -50,6 +50,6 @@ class JWTBaseModel(BaseModel):
         -------
         The JWT as a string
         """
-        data = self.dict()
+        data = self.model_dump()
         data['exp'] = self.exp
         return jwt.encode(data, key, algorithm='HS256')

--- a/spylib/utils/jwtoken.py
+++ b/spylib/utils/jwtoken.py
@@ -14,6 +14,8 @@ class JWTBaseModel(BaseModel):
 
     exp: int = None  # type: ignore
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator('exp', pre=True, always=True)
     def set_id(cls, exp):
         return exp or (now_epoch() + 900)

--- a/spylib/utils/jwtoken.py
+++ b/spylib/utils/jwtoken.py
@@ -1,7 +1,7 @@
-from typing import Optional
+from typing import Annotated, Optional
 
 import jwt
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from .misc import now_epoch
 
@@ -14,12 +14,7 @@ class JWTBaseModel(BaseModel):
     expiration time.
     """
 
-    exp: Optional[int] = None
-
-    @field_validator('exp', mode='before')
-    @classmethod
-    def set_id(cls, exp: int):
-        return exp or (now_epoch() + 900)
+    exp: Annotated[Optional[int], Field(default_factory=lambda: now_epoch() + 900 )]
 
     @classmethod
     def decode_token(cls, key: str, token: str, verify: bool = True):

--- a/spylib/utils/jwtoken.py
+++ b/spylib/utils/jwtoken.py
@@ -1,5 +1,7 @@
+from typing import Optional
+
 import jwt
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 from .misc import now_epoch
 
@@ -12,12 +14,11 @@ class JWTBaseModel(BaseModel):
     expiration time.
     """
 
-    exp: int = None  # type: ignore
+    exp: Optional[int] = None
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator('exp', pre=True, always=True)
-    def set_id(cls, exp):
+    @field_validator('exp', mode="before")
+    @classmethod
+    def set_id(cls, exp: int):
         return exp or (now_epoch() + 900)
 
     @classmethod

--- a/spylib/utils/jwtoken.py
+++ b/spylib/utils/jwtoken.py
@@ -1,7 +1,5 @@
-from typing import Annotated, Optional
-
 import jwt
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from .misc import now_epoch
 
@@ -14,7 +12,7 @@ class JWTBaseModel(BaseModel):
     expiration time.
     """
 
-    exp: Annotated[Optional[int], Field(default_factory=lambda: now_epoch() + 900 )]
+    exp: int = Field(default_factory=lambda: now_epoch() + 900)
 
     @classmethod
     def decode_token(cls, key: str, token: str, verify: bool = True):

--- a/spylib/utils/jwtoken.py
+++ b/spylib/utils/jwtoken.py
@@ -16,7 +16,7 @@ class JWTBaseModel(BaseModel):
 
     exp: Optional[int] = None
 
-    @field_validator('exp', mode="before")
+    @field_validator('exp', mode='before')
     @classmethod
     def set_id(cls, exp: int):
         return exp or (now_epoch() + 900)

--- a/spylib/utils/misc.py
+++ b/spylib/utils/misc.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Any, List
 
 from .shortuuid import random
 
@@ -9,3 +10,9 @@ def now_epoch() -> int:
 
 def get_unique_id() -> str:
     return random(length=10)
+
+
+def parse_scope(v: Any) -> List[str]:
+    if isinstance(v, str):
+        return v.split(',')
+    return v

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -91,7 +91,13 @@ async def test_oauth_with_fastapi(mocker):
     assert response.status_code == 422
     assert response.json() == {
         'detail': [
-            {'loc': ['query', 'shop'], 'msg': 'field required', 'type': 'value_error.missing'}
+            {
+                'input': None,
+                'loc': ['query', 'shop'],
+                'msg': 'Field required',
+                'type': 'missing',
+                'url': 'https://errors.pydantic.dev/2.5/v/missing',
+            }
         ],
     }
 

--- a/tests/oauth/test_exchange_token.py
+++ b/tests/oauth/test_exchange_token.py
@@ -58,4 +58,4 @@ async def test_exchange_token(respx_mock: MockRouter, token_dict, token_model):
         api_secret_key=api_secret_key,
     )
 
-    assert result == token_model.parse_obj(token_dict)
+    assert result == token_model.model_validate(token_dict)

--- a/tests/test_session_token.py
+++ b/tests/test_session_token.py
@@ -4,6 +4,7 @@ from sys import modules
 
 import jwt
 import pytest
+from pydantic import HttpUrl
 from starlette.requests import Request
 
 from spylib.session_token import (
@@ -50,7 +51,10 @@ async def test_session_token(token):
     valid_auth_header = generate_auth_header(token)
     session_token = SessionToken.from_header(valid_auth_header, API_KEY, API_SECRET)
 
-    assert session_token.dict() == token
+    token['iss'] = HttpUrl(token['iss'])
+    token['dest'] = HttpUrl(token['dest'])
+
+    assert session_token.model_dump() == token
 
 
 @pytest.mark.asyncio

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from json import loads
 from typing import ClassVar, Optional
 
-from pydantic.class_validators import validator
-from pydantic.main import BaseModel
+from pydantic.main import BaseModel, field_validator
 
 from spylib.admin_api import OfflineTokenABC, OnlineTokenABC, PrivateTokenABC
 from spylib.oauth.models import OfflineTokenModel, OnlineTokenModel
@@ -37,7 +36,8 @@ class MockHTTPResponse(BaseModel):
     jsondata: Optional[dict] = None
     headers: Optional[dict] = None
 
-    @validator('headers', pre=True, always=True)
+    @field_validator('headers', mode='before')
+    @classmethod
     def set_id(cls, fld):
         return fld or {'X-Shopify-Shop-Api-Call-Limit': '39/40'}
 

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from json import loads
 from typing import ClassVar, Optional
 
-from pydantic.main import BaseModel, field_validator
+from pydantic import BaseModel, field_validator
 
 from spylib.admin_api import OfflineTokenABC, OnlineTokenABC, PrivateTokenABC
 from spylib.oauth.models import OfflineTokenModel, OnlineTokenModel

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from json import loads
-from typing import Annotated, ClassVar, Optional
+from typing import ClassVar, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel
 
 from spylib.admin_api import OfflineTokenABC, OnlineTokenABC, PrivateTokenABC
 from spylib.oauth.models import OfflineTokenModel, OnlineTokenModel
@@ -34,12 +34,7 @@ offline_token_data = OfflineTokenModel(
 class MockHTTPResponse(BaseModel):
     status_code: int
     jsondata: Optional[dict] = None
-    headers: Annotated[Optional[dict], Field(validate_default=True)] = None
-
-    @field_validator('headers', mode='before')
-    @classmethod
-    def set_default_headers(cls, headers):
-        return headers or {'X-Shopify-Shop-Api-Call-Limit': '39/40'}
+    headers: dict = {'X-Shopify-Shop-Api-Call-Limit': '39/40'}
 
     def json(self):
         # Mock trying to deserialize something that's not a valid JSON

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from json import loads
-from typing import ClassVar, Optional
+from typing import Annotated, ClassVar, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from spylib.admin_api import OfflineTokenABC, OnlineTokenABC, PrivateTokenABC
 from spylib.oauth.models import OfflineTokenModel, OnlineTokenModel
@@ -34,12 +34,12 @@ offline_token_data = OfflineTokenModel(
 class MockHTTPResponse(BaseModel):
     status_code: int
     jsondata: Optional[dict] = None
-    headers: Optional[dict] = None
+    headers: Annotated[Optional[dict], Field(validate_default=True)] = None
 
     @field_validator('headers', mode='before')
     @classmethod
-    def set_id(cls, fld):
-        return fld or {'X-Shopify-Shop-Api-Call-Limit': '39/40'}
+    def set_default_headers(cls, headers):
+        return headers or {'X-Shopify-Shop-Api-Call-Limit': '39/40'}
 
     def json(self):
         # Mock trying to deserialize something that's not a valid JSON


### PR DESCRIPTION
To get our projects to use pydantic 2, we need to also upgrade SPyLib so here we are!

Much easier than expected thanks to [bump-pydantic](https://docs.pydantic.dev/dev/migration/#code-transformation-tool) which made it easy.

When it couldn't do the change itself, it left a comment with instructions on what and how to do it. Very handy!