### PR TITLE
💥 Remove support for python version 3.8, add 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pydocstyle = "^6.3.0"
 linkcheckmd= "^1.4.0"
 respx = "^0.20.2"
 mike = "^1.1.2"
+pytest-asyncio = "^0.23.2"
 
 [tool.poetry.extras]
 fastapi = ["fastapi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ homepage = "https://satelcreative.github.io/spylib"
 repository = "https://github.com/SatelCreative/spylib"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 httpx = ">= 0.18.1 <= 0.24.1"
 tenacity = "^8.2.2"
 starlette = ">= 0.15.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ pytest-cov = "^4.1.0"
 pytest-mock = "^3.11.1"
 mypy = "^1.4.1"
 mypy-extensions = "^1.0.0"
-# latest blue 0.9.1 is not compatible with flake8 v5
 flake8 = "^6.0.0"
 flake8-isort = "^6.0.0"
 python-box = "^7.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pytest-mock = "^3.11.1"
 mypy = "^1.4.1"
 mypy-extensions = "^1.0.0"
 # latest blue 0.9.1 is not compatible with flake8 v5
-flake8 = "^5.0.0"
+flake8 = "^6.0.0"
 flake8-isort = "^6.0.0"
 python-box = "^7.0.1"
 watchdog = "^3.0.0"

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -72,7 +72,7 @@ class Token(ABC, BaseModel):
 
     @validator('scope', pre=True)
     def convert_scope(cls, v):
-        if type(v) == str:
+        if isinstance(v, str):
             return v.split(',')
         return v
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py{38,39,310,311}, with_fastapi
+envlist = py{39,310,311,312}, with_fastapi
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.12: py312
     3.11: py311, with_fastapi
 
 [testenv]


### PR DESCRIPTION
In preparation of switching to pydantic version 2, we need to remove the support for python 3.8.
Pydantic 2 uses quite a lot `Annotated` in particular which was introduced in python 3.9 so it's just easier to drop 3.8.

I took this opportunity to add 3.12.