### PR TITLE
⬆️ Upgrade packages in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,47 +16,46 @@ python = "^3.8"
 httpx = ">= 0.18.1 <= 0.24.1"
 tenacity = "^8.2.2"
 starlette = ">= 0.15.0"
-pydantic ="^1.8.2"
+pydantic = "1.10.13"
 PyJWT = "^2.1.0"
 pycryptodome = "^3.10.1"
 
-fastapi = { version = ">= 0.69.0 < 0.100.0", optional = true }
-
-[tool.poetry.dev-dependencies]
-blue = "0.9.1"
-pytest = "7.4.0"
-pytest-asyncio = "0.21.1"
-pytest-cov = "4.1.0"
-pytest-mock = "3.11.1"
-mypy = "1.4.1"
-mypy-extensions = "1.0.0"
-# latest blue 0.9.1 is not compatible with flake8 v5
-flake8 = "4.0.1"
-flake8-isort = "6.0.0"
-python-box = "7.0.1"
-watchdog = "3.0.0"
-PyYAML = "6.0.1"
-argh = "0.28.1"
-tox = "4.6.4"
-mkdocs = "1.4.3"
-mkdocs-awesome-pages-plugin = "v2.9.1"
-mkdocs-material = "9.1.18"
-lazydocs = "0.4.8"
-pydocstyle = "6.3.0"
-linkcheckmd= "1.4.0"
-respx = "0.20.2"
-mike = "1.1.2"
-
+fastapi = { version = ">= 0.69.0", optional = true }
 
 [tool.poetry.extras]
 fastapi = ["fastapi"]
+
+[tool.poetry.group.dev.dependencies]
+black = "^23.11.0"
+pytest = "^7.4.0"
+pytest-cov = "^4.1.0"
+pytest-mock = "^3.11.1"
+mypy = "^1.4.1"
+mypy-extensions = "^1.0.0"
+# latest blue 0.9.1 is not compatible with flake8 v5
+flake8 = "^5.0.0"
+flake8-isort = "^6.0.0"
+python-box = "^7.0.1"
+watchdog = "^3.0.0"
+PyYAML = "^6.0.1"
+argh = "^0.28.1"
+tox = "^4.6.4"
+mkdocs = "^1.4.3"
+mkdocs-awesome-pages-plugin = "^v2.9.1"
+mkdocs-material = "^9.1.18"
+lazydocs = "^0.4.8"
+pydocstyle = "^6.3.0"
+linkcheckmd= "^1.4.0"
+respx = "^0.20.2"
+mike = "^1.1.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.blue]
+[tool.black]
 line-length = 99
+skip_string_normalization = true
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ pycryptodome = "^3.10.1"
 
 fastapi = { version = ">= 0.69.0", optional = true }
 
-[tool.poetry.extras]
-fastapi = ["fastapi"]
-
 [tool.poetry.group.dev.dependencies]
 black = "^23.11.0"
 pytest = "^7.4.0"
@@ -48,6 +45,9 @@ pydocstyle = "^6.3.0"
 linkcheckmd= "^1.4.0"
 respx = "^0.20.2"
 mike = "^1.1.2"
+
+[tool.poetry.extras]
+fastapi = ["fastapi"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/spylib/hmac.py
+++ b/spylib/hmac.py
@@ -22,7 +22,6 @@ def calculate_from_components(
 
 
 def validate(secret: str, sent_hmac: str, message: str, use_base64: bool = False):
-
     hmac_calculated = calculate_from_message(secret=secret, message=message, use_base64=use_base64)
 
     if not compare_digest(sent_hmac, hmac_calculated):

--- a/spylib/oauth/callback.py
+++ b/spylib/oauth/callback.py
@@ -19,7 +19,6 @@ async def process_callback(
     post_install: Callable[[str, OfflineTokenModel], Optional[Awaitable]],
     post_login: Optional[Callable[[str, OnlineTokenModel], Optional[Awaitable]]],
 ) -> OAuthJWT:
-
     validate_callback(
         shop=shop,
         timestamp=timestamp,

--- a/spylib/oauth/exchange_token.py
+++ b/spylib/oauth/exchange_token.py
@@ -40,7 +40,7 @@ async def exchange_token(
         message = (
             f'Shopify rejected token exchange. Shop: "{shop}". Status: "{response.status_code}".'
         )
-        raise Exception(message)   # Not sure what the convention is here
+        raise Exception(message)  # Not sure what the convention is here
 
     raw_response_body = response.json()
     is_online_token = 'associated_user' in raw_response_body

--- a/spylib/oauth/redirects.py
+++ b/spylib/oauth/redirects.py
@@ -48,5 +48,4 @@ def app_redirect(
     app_domain: str,
     app_api_key: str,
 ) -> str:
-
     return f'https://{store_domain}/admin/apps/{app_api_key}'

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
     poetry run pytest --cov=spylib --cov-report term-missing tests/
     mypy spylib
     flake8 spylib tests
-    blue spylib tests --check
+    black spylib tests --check
     linkcheckMarkdown docs
     lazydocs --validate spylib
 


### PR DESCRIPTION
A lot of the dependencies were fixed to a specific version preventing proper upgrades. This is causing issues in the other PRs such as flake8 not working with python 3.12.

This upgrade will fix these issues and was needed anyway.
Blue doesn't seem maintained anymore since it doesn't support flake8 >= 5.0.0. So back to black!