### PR TITLE
🐛  Shopify error handling

### DIFF
--- a/scripts/test_suite.sh
+++ b/scripts/test_suite.sh
@@ -23,7 +23,7 @@ FLAKE8OUT=`flake8`
 reportvalidation "$FLAKE8OUT"
 
 echo -ne "\n######### CHECK FORMATTING: "
-BLACKOUT=`blue spylib tests --check 2>&1`
+BLACKOUT=`black spylib tests --check 2>&1`
 if [[ $BLACKOUT == "All done!"* ]]
 then
   echo "OK"

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -204,8 +204,8 @@ class Token(ABC, BaseModel):
 
             error_msg = jsondata['errors']
             raise ShopifyGQLError(
-                    f'GQL query failed, status code: {resp.status_code}. {error_msg}'
-                )
+                f'GQL query failed, status code: {resp.status_code}. {error_msg}'
+            )
 
         try:
             jsondata = resp.json()

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -197,14 +197,15 @@ class Token(ABC, BaseModel):
         # Handle any response that is not 200, which will return with error message
         # https://shopify.dev/api/admin-graphql#status_and_error_codes
         if resp.status_code != 200:
-            jsondata = resp.json()
-            if jsondata:
-                error_msg = jsondata['errors']
-                raise ShopifyGQLError(
+            try:
+                jsondata = resp.json()
+            except JSONDecodeError:
+                raise ShopifyGQLError(f'GQL query failed, status code: {resp.status_code}.')
+
+            error_msg = jsondata['errors']
+            raise ShopifyGQLError(
                     f'GQL query failed, status code: {resp.status_code}. {error_msg}'
                 )
-            else:
-                raise ShopifyGQLError(f'GQL query failed, status code: {resp.status_code}.')
 
         try:
             jsondata = resp.json()

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -207,13 +207,11 @@ class Token(ABC, BaseModel):
         if resp.status_code != 200:
             try:
                 jsondata = resp.json()
+                error_msg = f'{resp.status_code}. {jsondata["errors"]}'
             except JSONDecodeError:
-                raise ShopifyGQLError(f'GQL query failed, status code: {resp.status_code}.')
+                error_msg = f'{resp.status_code}.'
 
-            error_msg = jsondata['errors']
-            raise ShopifyGQLError(
-                f'GQL query failed, status code: {resp.status_code}. {error_msg}'
-            )
+            raise ShopifyGQLError(f'GQL query failed, status code: {error_msg}')
 
         try:
             jsondata = resp.json()

--- a/spylib/admin_api.py
+++ b/spylib/admin_api.py
@@ -27,6 +27,7 @@ from spylib.exceptions import (
     ShopifyError,
     ShopifyExceedingMaxCostError,
     ShopifyGQLError,
+    ShopifyIntermittentError,
     ShopifyInvalidResponseBody,
     ShopifyThrottledError,
     not_our_fault,
@@ -167,7 +168,9 @@ class Token(ABC, BaseModel):
     @retry(
         reraise=True,
         stop=stop_after_attempt(API_CALL_NUMBER_RETRY_ATTEMPTS),
-        retry=retry_if_exception_type((ShopifyThrottledError, ShopifyInvalidResponseBody)),
+        retry=retry_if_exception_type(
+            (ShopifyThrottledError, ShopifyInvalidResponseBody, ShopifyIntermittentError)
+        ),
     )
     async def execute_gql(
         self,
@@ -196,6 +199,11 @@ class Token(ABC, BaseModel):
 
         # Handle any response that is not 200, which will return with error message
         # https://shopify.dev/api/admin-graphql#status_and_error_codes
+        if resp.status_code in [500, 503]:
+            raise ShopifyIntermittentError(
+                f'The Shopify API returned an intermittent error: {resp.status_code}.'
+            )
+
         if resp.status_code != 200:
             try:
                 jsondata = resp.json()

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -10,6 +10,12 @@ class ShopifyGQLError(Exception):
     pass
 
 
+class ShopifyIntermittentError(Exception):
+    """Exception to identify any Shopify admin API Intermittent error."""
+
+    pass
+
+
 class ShopifyGQLUserError(Exception):
     """Exception to identify any Shopify admin graphql error caused by the user mistake."""
 

--- a/tests/admin_api/test_graphql_base.py
+++ b/tests/admin_api/test_graphql_base.py
@@ -138,7 +138,7 @@ async def test_store_graphql_non_200(mocker):
 
 
 @pytest.mark.asyncio
-async def test_store_graphql_non_503(mocker):
+async def test_store_graphql_503(mocker):
     token = await OfflineToken.load(store_name=test_information.store_name)
 
     query = """


### PR DESCRIPTION
When Shopify GQL API returns 503 Service Unavailable, the content of the response is not JSON. 

The error being raise from AprilAire is 
```
  raise JSONDecodeError("Expecting value", s, err.value) from None
          │                                  └ '<!--\n  The source of truth for this generic error page is https://github.com/Shopify/error-pages.\n  Please do not edit thi...
          └ <class 'json.decoder.JSONDecodeError'>
```

Add retry to intermittent errors for 500 and 503 error codes
Add a try block for the json parsing to throw a more informative error for non 200 returns