### PR TITLE
🐛 fix store domain regex

### DIFF
--- a/spylib/utils/domain.py
+++ b/spylib/utils/domain.py
@@ -11,7 +11,7 @@ def domain_to_storename(domain: str) -> str:
 
 def store_domain(shop: str) -> str:
     """Conversion of a shop's subdomain or complete or incomplete url into a complete url."""
-    result = search(r'^(https:\/\/)?([a-z1-9\-]+)(\.myshopify\.com[\/]?)?$', shop.lower())
+    result = search(r'^(https:\/\/)?([^.]+)(\.myshopify\.com[\/]?)?$', shop.lower())
     if not result:
         raise ValueError(f'{shop} is not a shopify shop')
 

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -11,7 +11,7 @@ from pydantic.dataclasses import dataclass
 
 from spylib import hmac
 from spylib.exceptions import FastAPIImportError
-from spylib.utils import JWTBaseModel, now_epoch
+from spylib.utils import JWTBaseModel, domain_to_storename, now_epoch, store_domain
 
 SHOPIFY_API_KEY = 'API_KEY'
 SHOPIFY_SECRET_KEY = 'SECRET_KEY'
@@ -212,3 +212,17 @@ def check_oauth_redirect_query(query: str, scope: List[str], query_extra: dict =
     assert parsed_query == expected_query
 
     return state
+
+
+def test_domain_to_storename():
+    assert domain_to_storename(domain='test.myshopify.com') == 'test'
+    assert domain_to_storename(domain='test2.myshopify.com') == 'test2'
+    assert domain_to_storename(domain='test-v2.myshopify.com') == 'test-v2'
+    assert domain_to_storename(domain='test-2-0.myshopify.com') == 'test-2-0'
+
+
+def test_store_domain():
+    assert store_domain(shop='test.myshopify.com') == 'test.myshopify.com'
+    assert store_domain(shop='test-2.myshopify.com') == 'test-2.myshopify.com'
+    assert store_domain(shop='test-v2.myshopify.com') == 'test-v2.myshopify.com'
+    assert store_domain(shop='test-2-0.myshopify.com') == 'test-2-0.myshopify.com'

--- a/tests/oauth/test_base.py
+++ b/tests/oauth/test_base.py
@@ -90,8 +90,6 @@ async def test_oauth_with_fastapi(mocker):
     response = client.get('/shopify/auth')
     assert response.status_code == 422
     response_json = response.json()
-    # the url will change according to the pydantic version installed
-    del response_json['detail'][0]['url']
     assert response_json == {
         'detail': [
             {'input': None, 'loc': ['query', 'shop'], 'msg': 'Field required', 'type': 'missing'}

--- a/tests/token_classes.py
+++ b/tests/token_classes.py
@@ -36,11 +36,11 @@ class MockHTTPResponse(BaseModel):
     jsondata: Optional[dict] = None
     headers: dict = {'X-Shopify-Shop-Api-Call-Limit': '39/40'}
 
-    def json(self):
+    def json(self):  # type: ignore[override]
         # Mock trying to deserialize something that's not a valid JSON
         if self.jsondata is None:
-            loads('NOT A JSON')
-        return self.jsondata
+            loads('Not a JSON')
+        return self.jsondata  # type: ignore[return-value]
 
 
 class TestInformation(BaseModel):


### PR DESCRIPTION
### issue
the `store_domain` failed at verifying `test-2-0.myshopify.com`

### change
- update `store_domain` function to use the same regex with the `domain_to_storename`
- add tests