### PR TITLE
:alien: Fix webhook registration - remove deprecated private metafield

### DIFF
--- a/spylib/session_token.py
+++ b/spylib/session_token.py
@@ -42,7 +42,7 @@ class SessionToken(BaseModel):
     iss: HttpUrl
     dest: HttpUrl
     aud: Optional[str] = None
-    sub: int
+    sub: str
     exp: Optional[float] = None
     nbf: Optional[float] = None
     iat: Optional[float] = None

--- a/spylib/webhook/__init__.py
+++ b/spylib/webhook/__init__.py
@@ -76,7 +76,6 @@ async def create_event_bridge(
     arn: str,
     include_fields: Optional[List[str]] = None,
     metafield_namespaces: Optional[List[str]] = None,
-    private_metafield_namespaces: Optional[List[str]] = None,
 ) -> WebhookResponse:
     """Creates an Amazon EventBridge webhook subscription.
 
@@ -89,7 +88,6 @@ async def create_event_bridge(
             'format': 'JSON',
             'includeFields': include_fields,
             'metafieldNamespaces': metafield_namespaces,
-            'privateMetafieldNamespaces': private_metafield_namespaces,
             'arn': arn,
         },
     }
@@ -111,7 +109,6 @@ async def create_pub_sub(
     pub_sub_topic: str,
     include_fields: Optional[List[str]] = None,
     metafield_namespaces: Optional[List[str]] = None,
-    private_metafield_namespaces: Optional[List[str]] = None,
 ) -> WebhookResponse:
     """Creates a Google Cloud Pub/Sub webhook subscription.
 
@@ -123,7 +120,6 @@ async def create_pub_sub(
             'format': 'JSON',
             'includeFields': include_fields,
             'metafieldNamespaces': metafield_namespaces,
-            'privateMetafieldNamespaces': private_metafield_namespaces,
             'pubSubProject': pub_sub_project,
             'pubSubTopic': pub_sub_topic,
         },

--- a/spylib/webhook/__init__.py
+++ b/spylib/webhook/__init__.py
@@ -45,7 +45,6 @@ async def create_http(
     callback_url: str,
     include_fields: Optional[List[str]] = None,
     metafield_namespaces: Optional[List[str]] = None,
-    private_metafield_namespaces: Optional[List[str]] = None,
 ) -> WebhookResponse:
     """Creates a HTTP webhook subscription.
 
@@ -57,7 +56,6 @@ async def create_http(
             'format': 'JSON',
             'includeFields': include_fields,
             'metafieldNamespaces': metafield_namespaces,
-            'privateMetafieldNamespaces': private_metafield_namespaces,
             'callbackUrl': callback_url,
         },
     }

--- a/tests/test_session_token.py
+++ b/tests/test_session_token.py
@@ -28,7 +28,7 @@ def get_token():
         'iss': 'https://test.myshopify.com/admin',
         'dest': 'https://test.myshopify.com',
         'aud': API_KEY,
-        'sub': 1,
+        'sub': "1",
         'exp': (now + timedelta(0, 60)).timestamp(),
         'nbf': (now - timedelta(0, 60)).timestamp(),
         'iat': now.timestamp(),


### PR DESCRIPTION

remove the deprecated private metafield from webhook registration