### PR TITLE
🔖 Release 0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
 
+#### [0.10.6](https://github.com/SatelCreative/spylib/compare/0.10.5...0.10.6)
+> 07 January 2026
+* :alien: Oauth client credientials grant access token by @lishanl in https://github.com/SatelCreative/spylib/pull/231
+
+
 #### [0.10.5](https://github.com/SatelCreative/spylib/compare/0.10.4...0.10.5)
 > 14 July 2025
 * ✨ Add filter parameter to webhook creation functions by @lishanl in https://github.com/SatelCreative/spylib/pull/229

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spylib"
-version = "0.10.5"
+version = "0.10.6"
 description = "A library to facilitate interfacing with Shopify's API"
 authors = ["Anthony Hillairet <ant@satel.ca>"]
 maintainers = ["Anthony Hillairet <ant@satel.ca>", "Lishan Luo <lishan@satel.ca>", "Frank Chung <frank@satel.ca>"]

--- a/spylib/__init__.py
+++ b/spylib/__init__.py
@@ -1,3 +1,3 @@
 """A library to facilitate interfacing with Shopify's API."""
 
-__version__ = '0.10.5'
+__version__ = '0.10.6'


### PR DESCRIPTION
Release the new offline line token method `offline_token.obtain_client_credentials_token(<client_id>, <client_scerent>)` to work with the new [Shopify client credentials grant access token](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/client-credentials-grant)